### PR TITLE
Make GatewayFactory::create method static

### DIFF
--- a/src/Omnipay/Common/GatewayFactory.php
+++ b/src/Omnipay/Common/GatewayFactory.php
@@ -68,7 +68,7 @@ class GatewayFactory
      * @param ClientInterface|null $httpClient  A Guzzle HTTP Client implementation
      * @param HttpRequest|null     $httpRequest A Symfony HTTP Request implementation
      */
-    public function create($class, ClientInterface $httpClient = null, HttpRequest $httpRequest = null)
+    public static function create($class, ClientInterface $httpClient = null, HttpRequest $httpRequest = null)
     {
         $class = Helper::getGatewayClassName($class);
 


### PR DESCRIPTION
Factory methods should be static. This will clean up a lot of notices on my servers. (:
