### PR TITLE
add isTransparentRedirect function

### DIFF
--- a/src/Omnipay/Common/Message/AbstractResponse.php
+++ b/src/Omnipay/Common/Message/AbstractResponse.php
@@ -32,7 +32,7 @@ abstract class AbstractResponse implements ResponseInterface
 
     public function isTransparentRedirect()
     {
-      return false;
+        return false;
     }
 
     public function getData()


### PR DESCRIPTION
Further to discussion on google groups it seems that the first part of better support for transparent redirects is to have a simple way to check if the gateway is of this sort. 

You mentioned adding the property $isTransparentRedirect - but the calling function would need to test whether that property exists - which seems less elegant than the pattern you have used elsewhere - so I propose adding a dummy function to the parent Gateway that looks like the isRedirect function
