### PR TITLE
Ensure short number cannot be considered as valid credit card number

### DIFF
--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -140,6 +140,10 @@ class CreditCard
         if (!Helper::validateLuhn($this->getNumber())) {
             throw new InvalidCreditCardException('Card number is invalid');
         }
+
+	    if (!is_null($this->getNumber()) && !preg_match('/^\d{12,19}$/i', $this->getNumber())) {
+		    throw new InvalidCreditCardException('Card number should have 12 to 19 digits');
+	    }
     }
 
     public function getTitle()

--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -141,9 +141,9 @@ class CreditCard
             throw new InvalidCreditCardException('Card number is invalid');
         }
 
-	    if (!is_null($this->getNumber()) && !preg_match('/^\d{12,19}$/i', $this->getNumber())) {
-		    throw new InvalidCreditCardException('Card number should have 12 to 19 digits');
-	    }
+        if (!is_null($this->getNumber()) && !preg_match('/^\d{12,19}$/i', $this->getNumber())) {
+            throw new InvalidCreditCardException('Card number should have 12 to 19 digits');
+        }
     }
 
     public function getTitle()

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -596,6 +596,6 @@ class CreditCardTest extends TestCase
     public function testInvalidShortCard()
     {
         $this->card->setNumber('43');
-	    $this->card->validate();
+        $this->card->validate();
     }
 }

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -589,4 +589,13 @@ class CreditCardTest extends TestCase
         $this->card->setGender('female');
         $this->assertEquals('female', $this->card->getGender());
     }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidCreditCardException
+     */
+    public function testInvalidShortCard()
+    {
+        $this->card->setNumber('43');
+	    $this->card->validate();
+    }
 }


### PR DESCRIPTION
Or else, one can validate that `43` is a valid credit credit card number.