### PR TITLE
Add getUserMessage() function to response object

### DIFF
--- a/src/Omnipay/Common/Message/ResponseInterface.php
+++ b/src/Omnipay/Common/Message/ResponseInterface.php
@@ -55,4 +55,13 @@ interface ResponseInterface extends MessageInterface
      * @return string A reference provided by the gateway to represent this transaction
      */
     public function getTransactionReference();
+    
+    /**
+     * Gateway Reference
+     *
+     * @return string response message from the payment gateway with any adjustments required to make it more relevant to users
+     */
+    public function getUserMessage() {
+        return $this->getMessage();
+    }
 }


### PR DESCRIPTION
I am proposing this because some gateways return messages with supplementary data - e.g. Cybersource returns a message indicating invalid data and in a separate field the relevant field names. Also, some processors return reponses with 2 different levels of details e.g 'your transaction was not processed' to the user and 'arrest this person now' to the admin