### PR TITLE
Issue #17 and Issue #13

### DIFF
--- a/src/Omnipay/Common/Helper.php
+++ b/src/Omnipay/Common/Helper.php
@@ -5,6 +5,8 @@
 
 namespace Omnipay\Common;
 
+use InvalidArgumentException;
+
 /**
  * Helper class
  *
@@ -114,5 +116,31 @@ class Helper
         }
 
         return '\\Omnipay\\'.$shortName.'Gateway';
+    }
+
+    /**
+     * Convert an amount into a float.
+     * The float datatype can then be converted into the string
+     * format that the remote gateway requies.
+     *
+     * @var string|int|float $value The value to convert.
+     * @throws InvalidArgumentException on a validation failure.
+     * @return float The amount converted to a float.
+     */
+
+    public static function toFloat($value)
+    {
+        if (!is_string($value) && !is_int($value) && !is_float($value)) {
+            throw new InvalidArgumentException('Data type is not a valid decimal number.');
+        }
+
+        if (is_string($value)) {
+            // Validate generic number, with optional sign and decimals.
+            if (!preg_match('/^[-]?[0-9]+(\.[0-9]*)?$/', $value)) {
+                throw new InvalidArgumentException('String is not a valid decimal number.');
+            }
+        }
+
+        return (float)$value;
     }
 }

--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -164,7 +164,7 @@ abstract class AbstractRequest implements RequestInterface
         $message = 'Please specify amount as a string or float, '
             . 'with decimal places (e.g. \'10.00\' to represent $10.00).';
 
-        if (isset($amount)) {
+        if ($amount !== null) {
             // Don't allow integers for currencies that support decimals.
             // This is for legacy reasons - upgrades from v0.9
             if (is_int($amount) && $this->getCurrencyDecimalPlaces() > 0) {

--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -178,13 +178,13 @@ abstract class AbstractRequest implements RequestInterface
 
     public function toFloat($value)
     {
-        if ( ! is_string($value) && ! is_int($value) && ! is_float($value)) {
+        if (!is_string($value) && ! is_int($value) && ! is_float($value)) {
             throw new InvalidRequestException('Data type is not a valid decimal number.');
         }
 
         if (is_string($value)) {
             // Validate generic number, with optional sign and decimals.
-            if ( ! preg_match('/^[-]?[0-9]+(\.[0-9]*)?$/', $value)) {
+            if (!preg_match('/^[-]?[0-9]+(\.[0-9]*)?$/', $value)) {
                 throw new InvalidRequestException('String is not a valid decimal number.');
             }
         }
@@ -210,7 +210,7 @@ abstract class AbstractRequest implements RequestInterface
                 if (is_int($amount) || (is_string($amount) && false === strpos((string) $amount, '.'))) {
                     throw new InvalidRequestException(
                         'Please specify amount as a string or float, '
-                            . 'with decimal places (e.g. \'10.00\' to represent $10.00).'
+                        . 'with decimal places (e.g. \'10.00\' to represent $10.00).'
                     );
                 };
             }
@@ -218,12 +218,12 @@ abstract class AbstractRequest implements RequestInterface
             $amount = $this->toFloat($amount);
 
             // Check for a negative amount.
-            if ( ! $this->negativeAmountAllowed && $amount < 0) {
+            if (!$this->negativeAmountAllowed && $amount < 0) {
                 throw new InvalidRequestException('A negative amount is not allowed.');
             }
 
             // Check for a zero amount.
-            if ( ! $this->zeroAmountAllowed && $amount === 0.0) {
+            if (!$this->zeroAmountAllowed && $amount === 0.0) {
                 throw new InvalidRequestException('A zero amount is not allowed.');
             }
 

--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -159,6 +159,8 @@ abstract class AbstractRequest implements RequestInterface
     }
 
     /**
+     * Validates and returns the formated amount.
+     *
      * @throws InvalidRequestException on any validation failure.
      * @return string The amount formatted to the correct number of decimal places for the selected currency.
      */

--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -14,6 +14,7 @@ use Omnipay\Common\Helper;
 use Omnipay\Common\ItemBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use InvalidArgumentException;
 
 /**
  * Abstract Request
@@ -290,18 +291,12 @@ abstract class AbstractRequest implements RequestInterface
 
     public function toFloat($value)
     {
-        if (!is_string($value) && ! is_int($value) && ! is_float($value)) {
-            throw new InvalidRequestException('Data type is not a valid decimal number.');
+        try {
+            return Helper::toFloat($value);
+        } catch (InvalidArgumentException $e) {
+            // Throw old exception for legacy implementations.
+            throw new InvalidRequestException($e->getMessage(), $e->getCode(), $e);
         }
-
-        if (is_string($value)) {
-            // Validate generic number, with optional sign and decimals.
-            if (!preg_match('/^[-]?[0-9]+(\.[0-9]*)?$/', $value)) {
-                throw new InvalidRequestException('String is not a valid decimal number.');
-            }
-        }
-
-        return (float)$value;
     }
 
     /**

--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -161,7 +161,6 @@ abstract class AbstractRequest implements RequestInterface
     public function getAmount()
     {
         $amount = $this->getParameter('amount');
-<<<<<<< HEAD
         $message = 'Please specify amount as a string or float, '
             . 'with decimal places (e.g. \'10.00\' to represent $10.00).';
 
@@ -196,16 +195,7 @@ abstract class AbstractRequest implements RequestInterface
             $decimal_count = strlen(substr(strrchr((string)$amount, '.'), 1));
             if ($decimal_count > $this->getCurrencyDecimalPlaces()) {
                 throw new InvalidRequestException('Amount precision is too high for currency.');
-=======
-        if ($amount !== null) {
-            if (!is_float($amount) &&
-                $this->getCurrencyDecimalPlaces() > 0 &&
-                false === strpos((string) $amount, '.')) {
-                throw new InvalidRequestException(
-                    'Please specify amount as a string or float, ' .
-                    'with decimal places (e.g. \'10.00\' to represent $10.00).'
-                );
->>>>>>> 66a1999f3b20f4466855326220b6e42f49426548
+
             }
 
             return $this->formatCurrency($amount);

--- a/tests/Omnipay/Common/HelperTest.php
+++ b/tests/Omnipay/Common/HelperTest.php
@@ -134,4 +134,93 @@ class HelperTest extends TestCase
         $class = Helper::getGatewayClassName('PayPal_Express');
         $this->assertEquals('\\Omnipay\\PayPal\\ExpressGateway', $class);
     }
+
+    /**
+     * Some valid toFloat() inputs.
+     */
+    public function testToFloatFromFloat()
+    {
+        $shortName = Helper::toFloat(1.99);
+        $this->assertSame(1.99, $shortName);
+    }
+
+    public function testToFloatFromInt()
+    {
+        $shortName = Helper::toFloat(199);
+        $this->assertSame(199.0, $shortName);
+    }
+
+    public function testToFloatFromStringDecimal()
+    {
+        $shortName = Helper::toFloat("1.99");
+        $this->assertSame(1.99, $shortName);
+    }
+
+    public function testToFloatFromStringRedunantZeroes()
+    {
+        $shortName = Helper::toFloat("000009.99900000000");
+        $this->assertSame(9.999, $shortName);
+    }
+
+    public function testToFloatFromStringEmptyDecimal()
+    {
+        $shortName = Helper::toFloat("1.");
+        $this->assertSame(1.0, $shortName);
+    }
+
+    public function testToFloatFromStringInt()
+    {
+        $shortName = Helper::toFloat("199");
+        $this->assertSame(199.0, $shortName);
+    }
+
+    public function testToFloatFromStringIntNegative()
+    {
+        $shortName = Helper::toFloat("-199");
+        $this->assertSame(-199.0, $shortName);
+    }
+
+    /**
+     * Some invalid toFloat() inputs.
+     */
+
+    /**
+     * The number MUST always start with a digit.
+     * This is arguably an arbitrary rule that perhaps does not need
+     * to be enforced.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage String is not a valid decimal number
+     */
+    public function testToFloatFromStringEmptyIntegerPart()
+    {
+        $shortName = Helper::toFloat(".99");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage String is not a valid decimal number
+     */
+    public function testToFloatFromStringTwoDecimalPoints()
+    {
+        $shortName = Helper::toFloat("1.99.");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage String is not a valid decimal number
+     */
+    public function testToFloatFromStringWrongDecimalPoints()
+    {
+        $shortName = Helper::toFloat("1,99");
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Data type is not a valid decimal number
+     */
+    public function testToFloatFromBoolean()
+    {
+        $shortName = Helper::toFloat(false);
+    }
 }

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -87,6 +87,12 @@ class AbstractRequestTest extends TestCase
         $this->assertSame(null, $this->request->getAmount());
     }
 
+    public function testAmountZero()
+    {
+        $this->assertSame($this->request, $this->request->setAmount(0.0));
+        $this->assertSame('0.00', $this->request->getAmount());
+    }
+
     public function testGetAmountNoDecimals()
     {
         $this->assertSame($this->request, $this->request->setCurrency('JPY'));
@@ -94,11 +100,15 @@ class AbstractRequestTest extends TestCase
         $this->assertSame('1366', $this->request->getAmount());
     }
 
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     */
     public function testGetAmountNoDecimalsRounding()
     {
+        // There will not be any rounding; the amount is sent as requested or not at all.
         $this->assertSame($this->request, $this->request->setAmount('136.5'));
         $this->assertSame($this->request, $this->request->setCurrency('JPY'));
-        $this->assertSame('137', $this->request->getAmount());
+        $this->request->getAmount();
     }
 
     /**
@@ -117,6 +127,7 @@ class AbstractRequestTest extends TestCase
     public function testAmountWithIntStringThrowsException()
     {
         // ambiguous value, avoid errors upgrading from v0.9
+        // Some currencies only take integers, so an integer (in a string) should be valid.
         $this->assertSame($this->request, $this->request->setAmount('10'));
         $this->request->getAmount();
     }
@@ -132,6 +143,24 @@ class AbstractRequestTest extends TestCase
         $this->assertSame($this->request, $this->request->setCurrency('JPY'));
         $this->assertSame($this->request, $this->request->setAmount('1366'));
         $this->assertSame(1366, $this->request->getAmountInteger());
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testAmountThousandsSepThrowsException()
+    {
+        $this->assertSame($this->request, $this->request->setAmount('1,234.00'));
+        $this->request->getAmount();
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testAmountInvalidFormatThrowsException()
+    {
+        $this->assertSame($this->request, $this->request->setAmount('1.234.00'));
+        $this->request->getAmount();
     }
 
     public function testCurrency()

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -95,7 +95,7 @@ class AbstractRequestTest extends TestCase
 
     public function testAmountZeroString()
     {
-        $this->assertSame($this->request, $this->request->setAmount('0.0'));
+        $this->assertSame($this->request, $this->request->setAmount('0.000000'));
         $this->assertSame('0.00', $this->request->getAmount());
     }
 
@@ -166,6 +166,15 @@ class AbstractRequestTest extends TestCase
     public function testAmountInvalidFormatThrowsException()
     {
         $this->assertSame($this->request, $this->request->setAmount('1.234.00'));
+        $this->request->getAmount();
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testAmountInvalidTypeThrowsException()
+    {
+        $this->assertSame($this->request, $this->request->setAmount(true));
         $this->request->getAmount();
     }
 

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -87,9 +87,15 @@ class AbstractRequestTest extends TestCase
         $this->assertSame(null, $this->request->getAmount());
     }
 
-    public function testAmountZero()
+    public function testAmountZeroFloat()
     {
         $this->assertSame($this->request, $this->request->setAmount(0.0));
+        $this->assertSame('0.00', $this->request->getAmount());
+    }
+
+    public function testAmountZeroString()
+    {
+        $this->assertSame($this->request, $this->request->setAmount('0.0'));
         $this->assertSame('0.00', $this->request->getAmount());
     }
 
@@ -160,6 +166,24 @@ class AbstractRequestTest extends TestCase
     public function testAmountInvalidFormatThrowsException()
     {
         $this->assertSame($this->request, $this->request->setAmount('1.234.00'));
+        $this->request->getAmount();
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testAmountNegativeStringThrowsException()
+    {
+        $this->assertSame($this->request, $this->request->setAmount('-123.00'));
+        $this->request->getAmount();
+    }
+
+    /**
+     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testAmountNegativeFloatThrowsException()
+    {
+        $this->assertSame($this->request, $this->request->setAmount(-123.00));
         $this->request->getAmount();
     }
 


### PR DESCRIPTION
Being more consistent with the amount: getAmount() will always return a formatted string. Some additional checks on the format of the value passed in (floats, integers and strings are allowed, so long as their value is unambiguous - integers still not accepted for currencies that support decimals, for legacy reasons).

Zero amounts now explicitly allowed, and negative amounts checked for. However, both of these can be reversed by overriding the appropriate properties.

Decimal point is still always "." regardless of locale. This is derived from the PHP format for floats, which always uses a ".". Any gateway that needs to send other decimal characters to the remote gateway, will need to overwrite getAmount().