### PR TITLE
Change abandoned guzzle/http to guzzle/guzzle (fixes #33)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 before_script:
   - composer require symfony/http-foundation:${SYMFONY_VERSION} --no-update
-  - composer require guzzle/http:${GUZZLE_VERSION} --no-update
+  - composer require guzzle/guzzle:${GUZZLE_VERSION} --no-update
   - composer install -n --dev --prefer-source
 
 script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "guzzle/http": "~3.1",
+        "guzzle/guzzle": "~3.9",
         "symfony/http-foundation": "~2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Composer shows warnings in any project requiring omnipay-common, since guzzle/http is abandoned and no longer supported. This is not nice, esp. since this might introduce some security issues in future.