### PR TITLE
Suppress line length check on long phpdoc line

### DIFF
--- a/src/Omnipay/Omnipay.php
+++ b/src/Omnipay/Omnipay.php
@@ -45,7 +45,9 @@ use Omnipay\Common\GatewayFactory;
  * @method static string register(string $className)
  * @method static array  find()
  * @method static array  getSupportedGateways()
+ * @codingStandardsIgnoreStart
  * @method static \Omnipay\Common\GatewayInterface create(string $class, \Guzzle\Http\ClientInterface $httpClient = null, \Symfony\Component\HttpFoundation\Request $httpRequest = null)
+ * @codingStandardsIgnoreEnd
  *
  * @see Omnipay\Common\GatewayFactory
  */


### PR DESCRIPTION
phpcs (run by travis-ci) errors out on lines >120 characters.
Suppress this check for this long phpdoc tag line.