### PR TITLE
AbstractRequest::validate() errors on fields that are set but evaluate to empty()

### DIFF
--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -209,7 +209,7 @@ abstract class AbstractRequest implements RequestInterface
     {
         foreach (func_get_args() as $key) {
             $value = $this->parameters->get($key);
-            if (empty($value)) {
+            if (empty($value) && $value !== '0' && $value !== false) {
                 throw new InvalidRequestException("The $key parameter is required");
             }
         }


### PR DESCRIPTION
AbstractRequest::validate() fixed so that is does not throw an arror on parameters with a zero value. As discussed in https://github.com/thephpleague/omnipay-common/issues/13#issuecomment-65134123 