### PR TITLE
Added phone extension support to CreditCard object

### DIFF
--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -49,7 +49,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * * state
  * * country
  * * phone
- * * phoneExt
+ * * phoneExtension
  * * fax
  * * number
  * * expiryMonth

--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -49,6 +49,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * * state
  * * country
  * * phone
+ * * phoneExt
  * * fax
  * * number
  * * expiryMonth
@@ -822,6 +823,27 @@ class CreditCard
     }
 
     /**
+     * Get the billing phone number extension.
+     *
+     * @return string
+     */
+    public function getBillingPhoneExtension()
+    {
+        return $this->getParameter('billingPhoneExtension');
+    }
+
+    /**
+     * Sets the billing phone number extension.
+     *
+     * @param string $value
+     * @return CreditCard provides a fluent interface.
+     */
+    public function setBillingPhoneExtension($value)
+    {
+        return $this->setParameter('billingPhoneExtension', $value);
+    }
+
+    /**
      * Get the billing fax number.
      *
      * @return string
@@ -1099,6 +1121,27 @@ class CreditCard
     }
 
     /**
+     * Get the shipping phone number extension.
+     *
+     * @return string
+     */
+    public function getShippingPhoneExtension()
+    {
+        return $this->getParameter('shippingPhoneExtension');
+    }
+
+    /**
+     * Sets the shipping phone number extension.
+     *
+     * @param string $value
+     * @return CreditCard provides a fluent interface.
+     */
+    public function setShippingPhoneExtension($value)
+    {
+        return $this->setParameter('shippingPhoneExtension', $value);
+    }
+
+    /**
      * Get the shipping fax number.
      *
      * @return string
@@ -1283,6 +1326,30 @@ class CreditCard
     {
         $this->setParameter('billingPhone', $value);
         $this->setParameter('shippingPhone', $value);
+
+        return $this;
+    }
+
+    /**
+     * Get the billing phone number extension.
+     *
+     * @return string
+     */
+    public function getPhoneExtension()
+    {
+        return $this->getParameter('billingPhoneExtension');
+    }
+
+    /**
+     * Sets the billing and shipping phone number extension.
+     *
+     * @param string $value
+     * @return CreditCard provides a fluent interface.
+     */
+    public function setPhoneExtension($value)
+    {
+        $this->setParameter('billingPhoneExtension', $value);
+        $this->setParameter('shippingPhoneExtension', $value);
 
         return $this;
     }

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -403,6 +403,13 @@ class CreditCardTest extends TestCase
         $this->assertSame('12345', $this->card->getPhone());
     }
 
+    public function testBillingPhoneExtension()
+    {
+        $this->card->setBillingPhoneExtension('001');
+        $this->assertSame('001', $this->card->getBillingPhoneExtension());
+        $this->assertSame('001', $this->card->getPhoneExtension());
+    }
+
     public function testBillingFax()
     {
         $this->card->setBillingFax('54321');
@@ -487,6 +494,12 @@ class CreditCardTest extends TestCase
         $this->assertEquals('12345', $this->card->getShippingPhone());
     }
 
+    public function testShippingPhoneExtension()
+    {
+        $this->card->setShippingPhoneExtension('001');
+        $this->assertEquals('001', $this->card->getShippingPhoneExtension());
+    }
+
     public function testShippingFax()
     {
         $this->card->setShippingFax('54321');
@@ -555,6 +568,14 @@ class CreditCardTest extends TestCase
         $this->assertEquals('12345', $this->card->getPhone());
         $this->assertEquals('12345', $this->card->getBillingPhone());
         $this->assertEquals('12345', $this->card->getShippingPhone());
+    }
+
+    public function testPhoneExtension()
+    {
+        $this->card->setPhoneExtension('001');
+        $this->assertEquals('001', $this->card->getPhoneExtension());
+        $this->assertEquals('001', $this->card->getBillingPhoneExtension());
+        $this->assertEquals('001', $this->card->getShippingPhoneExtension());
     }
 
     public function testFax()


### PR DESCRIPTION
There are payment services like 2checkout (https://www.2checkout.com/documentation/payment-api/create-sale#) that also collect phone number extension besides the phone number.

This PR adds support for it.