### PR TITLE
alternate fix for PR 64

### DIFF
--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -209,7 +209,7 @@ abstract class AbstractRequest implements RequestInterface
     {
         foreach (func_get_args() as $key) {
             $value = $this->parameters->get($key);
-            if (empty($value)) {
+            if (! isset($value)) {
                 throw new InvalidRequestException("The $key parameter is required");
             }
         }


### PR DESCRIPTION
Fix AbstractRequest::validate() so that it does not throw an exception on parameters with a zero value.