### PR TITLE
Using system root certificates instead of the old and unmaintained on…

### DIFF
--- a/src/Omnipay/Common/AbstractGateway.php
+++ b/src/Omnipay/Common/AbstractGateway.php
@@ -335,6 +335,7 @@ abstract class AbstractGateway implements GatewayInterface
             '',
             array(
                 'curl.options' => array(CURLOPT_CONNECTTIMEOUT => 60),
+                'ssl.certificate_authority' => 'system',
             )
         );
     }


### PR DESCRIPTION
…es in guzzle/http

Just a temporary fix until v3.0 is ready