### PR TITLE
[3.0] Use integer for Amount instead of float

### DIFF
--- a/src/Omnipay/Common/Amount.php
+++ b/src/Omnipay/Common/Amount.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Amount class
+ */
+
+namespace Omnipay\Common;
+
+use InvalidArgumentException;
+
+/**
+ * Amount class
+ *
+ * This class abstracts certain functionality around amount and currencies in the Omnipay system.
+ */
+final class Amount
+{
+    /** @var  string */
+    private $amount;
+
+    /** @var  Currency */
+    private $currency;
+
+    /**
+     * Create a new Currency object
+     *
+     * @param string|int $amount
+     * @param string|Currency $currency
+     *
+     */
+    public function __construct($amount, $currency)
+    {
+        if (( ! is_int($amount) && ! is_string($amount)) || filter_var($amount, FILTER_VALIDATE_INT) === false) {
+            throw new InvalidArgumentException('Amount must be a valid integer');
+        }
+
+        $this->amount = (string) $amount;
+        $this->currency = self::findCurrency($currency);
+    }
+
+    /**
+     * Get the amount in smallest units (eg. cents)
+     *
+     * @return string
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Get the amount as decimal string
+     *
+     * @return string
+     */
+    public function getFormatted()
+    {
+        $decimals = $this->currency->getDecimals();
+        $amount = $this->amount / pow(10, $decimals);
+
+        return number_format(
+            $amount,
+            $decimals,
+            '.',
+            ''
+        );
+    }
+
+    /**
+     * Get the currency
+     *
+     * @return Currency
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNegative()
+    {
+        return $this->amount < 0;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isZero()
+    {
+        return $this->amount == 0;
+    }
+
+    /**
+     * Get the amount, based on a decimal string
+     *
+     * @param string|float $amount
+     * @param string|Currency $currency
+     * @return static
+     */
+    public static function fromDecimal($amount, $currency)
+    {
+        $amount = Helper::toFloat($amount);
+
+        $currency = self::findCurrency($currency);
+        $factor = pow(10, $currency->getDecimals());
+        $amount = (int) round($amount * $factor);
+
+        return new self($amount, $currency);
+    }
+
+    /**
+     * @param string|Currency $currencyCode
+     * @return Currency
+     */
+    private static function findCurrency($currencyCode)
+    {
+        if ($currencyCode instanceof Currency) {
+            return $currencyCode;
+        } elseif (is_string($currencyCode) || is_integer($currencyCode)) {
+            $currency = Currency::find($currencyCode);
+            if (is_null($currency)) {
+                throw new InvalidArgumentException('Invalid currency');
+            }
+            return $currency;
+        }
+
+        throw new InvalidArgumentException('Currency must be a string or Currency object');
+    }
+}

--- a/src/Omnipay/Common/Currency.php
+++ b/src/Omnipay/Common/Currency.php
@@ -71,8 +71,8 @@ class Currency
         $iso4217 = new ISO4217();
 
         try {
-            $currency = $iso4217->getByCode($code);
-        } catch (\OutOfBoundsException $e) {
+            $currency = $iso4217->getByAlpha3($code);
+        } catch (\Exception $e) {
             return null;
         }
 

--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -5,6 +5,7 @@
 
 namespace Omnipay\Common\Message;
 
+use Omnipay\Common\Amount;
 use Omnipay\Common\Http\ClientInterface;
 use Omnipay\Common\CreditCard;
 use Omnipay\Common\Currency;
@@ -283,153 +284,69 @@ abstract class AbstractRequest implements RequestInterface
     }
 
     /**
-     * Convert an amount into a float.
-     *
-     * @var string|int|float $value The value to convert.
-     * @throws InvalidRequestException on any validation failure.
-     * @return float The amount converted to a float.
+     * @return string
      */
-
-    public function toFloat($value)
+    protected function getCurrency()
     {
-        try {
-            return Helper::toFloat($value);
-        } catch (InvalidArgumentException $e) {
-            // Throw old exception for legacy implementations.
-            throw new InvalidRequestException($e->getMessage(), $e->getCode(), $e);
-        }
+        return strtoupper($this->getParameter('currency'));
     }
 
     /**
-     * Validates and returns the formated amount.
+     * @param  string $value
+     * @return $this
+     */
+    public function setCurrency($value)
+    {
+        return $this->setParameter('currency', $value);
+    }
+
+    /**
+     * Validates and returns  amount as integer.
      *
      * @throws InvalidRequestException on any validation failure.
-     * @return string The amount formatted to the correct number of decimal places for the selected currency.
+     * @return string The amount in smallest unit possible (eg. 'cents')
      */
     public function getAmount()
     {
         $amount = $this->getParameter('amount');
 
         if ($amount !== null) {
-            // Don't allow integers for currencies that support decimals.
-            // This is for legacy reasons - upgrades from v0.9
-            if ($this->getCurrencyDecimalPlaces() > 0) {
-                if (is_int($amount) || (is_string($amount) && false === strpos((string) $amount, '.'))) {
-                    throw new InvalidRequestException(
-                        'Please specify amount as a string or float, '
-                        . 'with decimal places (e.g. \'10.00\' to represent $10.00).'
-                    );
-                };
+            if (!$amount instanceof Amount) {
+
+                // Default currency when none set
+                $currency = $this->getCurrency();
+
+                if ($currency == null) {
+                    throw new InvalidRequestException('A currency is required.');
+                }
+
+                $amount = new Amount($amount, $currency);
             }
 
-            $amount = $this->toFloat($amount);
-
             // Check for a negative amount.
-            if (!$this->negativeAmountAllowed && $amount < 0) {
+            if (!$this->negativeAmountAllowed && $amount->isNegative()) {
                 throw new InvalidRequestException('A negative amount is not allowed.');
             }
 
             // Check for a zero amount.
-            if (!$this->zeroAmountAllowed && $amount === 0.0) {
+            if (!$this->zeroAmountAllowed && $amount->isZero()) {
                 throw new InvalidRequestException('A zero amount is not allowed.');
             }
 
-            // Check for rounding that may occur if too many significant decimal digits are supplied.
-            $decimal_count = strlen(substr(strrchr(sprintf('%.8g', $amount), '.'), 1));
-            if ($decimal_count > $this->getCurrencyDecimalPlaces()) {
-                throw new InvalidRequestException('Amount precision is too high for currency.');
-            }
-
-            return $this->formatCurrency($amount);
+            return $amount;
         }
     }
 
     /**
      * Sets the payment amount.
      *
-     * @param string $value
+     * @param string|Amount $value
      * @return AbstractRequest Provides a fluent interface
+     * @throws InvalidRequestException
      */
     public function setAmount($value)
     {
         return $this->setParameter('amount', $value);
-    }
-
-    /**
-     * Get the payment amount as an integer.
-     *
-     * @return integer
-     */
-    public function getAmountInteger()
-    {
-        return (int) round($this->getAmount() * $this->getCurrencyDecimalFactor());
-    }
-
-    /**
-     * Get the payment currency code.
-     *
-     * @return string
-     */
-    public function getCurrency()
-    {
-        return $this->getParameter('currency');
-    }
-
-    /**
-     * Sets the payment currency code.
-     *
-     * @param string $value
-     * @return AbstractRequest Provides a fluent interface
-     */
-    public function setCurrency($value)
-    {
-        return $this->setParameter('currency', strtoupper($value));
-    }
-
-    /**
-     * Get the payment currency number.
-     *
-     * @return integer
-     */
-    public function getCurrencyNumeric()
-    {
-        if ($currency = Currency::find($this->getCurrency())) {
-            return $currency->getNumeric();
-        }
-    }
-
-    /**
-     * Get the number of decimal places in the payment currency.
-     *
-     * @return integer
-     */
-    public function getCurrencyDecimalPlaces()
-    {
-        if ($currency = Currency::find($this->getCurrency())) {
-            return $currency->getDecimals();
-        }
-
-        return 2;
-    }
-
-    private function getCurrencyDecimalFactor()
-    {
-        return pow(10, $this->getCurrencyDecimalPlaces());
-    }
-
-    /**
-     * Format an amount for the payment currency.
-     *
-     * @return string
-     */
-    public function formatCurrency($amount)
-    {
-        return number_format(
-            $amount,
-            $this->getCurrencyDecimalPlaces(),
-            '.',
-            ''
-        );
     }
 
     /**

--- a/tests/Omnipay/Common/AmountTest.php
+++ b/tests/Omnipay/Common/AmountTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Omnipay\Common;
+
+use Omnipay\Tests\TestCase;
+
+class AmountTest extends TestCase
+{
+
+    public function testConstruct()
+    {
+        $amount = new Amount('1000', 'USD');
+        $this->assertSame('1000', $amount->getAmount());
+    }
+
+    public function testConstructInteger()
+    {
+        $amount = new Amount(1000, 'USD');
+        $this->assertSame('1000', $amount->getAmount());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructFloat()
+    {
+        new Amount(10.00, 'USD');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructDecimalString()
+    {
+        new Amount('10.00', 'USD');
+    }
+
+    public function testFromDecimal()
+    {
+        $amount = Amount::fromDecimal('10.00', 'USD');
+        $this->assertSame('1000', $amount->getAmount());
+    }
+
+    public function testFromDecimalRounded()
+    {
+        $amount = Amount::fromDecimal('10', 'USD');
+        $this->assertSame('1000', $amount->getAmount());
+
+        $amount = Amount::fromDecimal(10, 'USD');
+        $this->assertSame('1000', $amount->getAmount());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDecimalInvalid()
+    {
+        Amount::fromDecimal('1,234.00', 'USD');
+    }
+
+    public function testCurrencyString()
+    {
+        $amount = new Amount(1000, 'EUR');
+        $this->assertSame('EUR', $amount->getCurrency()->getCode());
+    }
+
+    public function testCurrencyObject()
+    {
+        $currency = Currency::find('EUR');
+        $amount = new Amount(1000, $currency);
+
+        $this->assertSame('EUR', $amount->getCurrency()->getCode());
+    }
+
+    public function testFormatted()
+    {
+        $amount = new Amount(1000, 'USD');
+
+        $this->assertSame('10.00', $amount->getFormatted());
+    }
+
+    public function testGetAmountNoDecimals()
+    {
+        $amount = new Amount(1366, 'JPY');
+
+        $this->assertSame('JPY', $amount->getCurrency()->getCode());
+        $this->assertSame('1366', $amount->getAmount());
+        $this->assertSame('1366', $amount->getFormatted());
+    }
+
+    public function testFromDecimalNoDecimals()
+    {
+        $amount = Amount::fromDecimal('10', 'JPY');
+        $this->assertSame('10', $amount->getAmount());
+    }
+
+    public function testIsNegative()
+    {
+        $amount = new Amount(-1, 'USD');
+        $this->assertTrue($amount->isNegative());
+
+        $amount = new Amount(0, 'USD');
+        $this->assertFalse($amount->isNegative());
+
+        $amount = new Amount(1, 'USD');
+        $this->assertFalse($amount->isNegative());
+    }
+
+    public function testIsZero()
+    {
+        $amount = new Amount(-1, 'USD');
+        $this->assertFalse($amount->isZero());
+
+        $amount = new Amount(0, 'USD');
+        $this->assertTrue($amount->isZero());
+
+        $amount = new Amount('0', 'USD');
+        $this->assertTrue($amount->isZero());
+
+        $amount = Amount::fromDecimal('0.00', 'USD');
+        $this->assertTrue($amount->isZero());
+
+        $amount = new Amount(1, 'USD');
+        $this->assertFalse($amount->isZero());
+    }
+
+    public function testAmountNegativeDecimalString()
+    {
+        $amount = Amount::fromDecimal('-123.00', 'USD');
+
+        $this->assertEquals('-12300', $amount->getAmount());
+        $this->assertTrue($amount->isNegative());
+    }
+
+    public function testAmountNegativeDecimalFloat()
+    {
+        $amount = Amount::fromDecimal(-123.00, 'USD');
+
+        $this->assertEquals('-12300', $amount->getAmount());
+        $this->assertTrue($amount->isNegative());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAmountThousandsSepThrowsException()
+    {
+        Amount::fromDecimal('1,234', 'USD');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAmountInvalidFormatThrowsException()
+    {
+        new Amount('1.234', 'USD');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAmountInvalidTypeThrowsException()
+    {
+        new Amount(true, 'USD');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAmountNegativeStringThrowsException()
+    {
+        new Amount('-123.00', 'USD');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAmountNegativeFloatThrowsException()
+    {
+        new Amount(-123.00, 'USD');
+    }
+}

--- a/tests/Omnipay/Common/CurrencyTest.php
+++ b/tests/Omnipay/Common/CurrencyTest.php
@@ -25,6 +25,13 @@ class CurrencyTest extends TestCase
         $this->assertSame(2, $currency->getDecimals());
     }
 
+    public function testNumericCodeReturnsNull()
+    {
+        $currency = Currency::find('840');
+
+        $this->assertNull($currency);
+    }
+
     public function testUnknownCurrencyReturnsNull()
     {
         $currency = Currency::find('XYZ');

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Common\Message;
 
 use Mockery as m;
+use Omnipay\Common\Amount;
 use Omnipay\Common\CreditCard;
 use Omnipay\Common\ItemBag;
 use Omnipay\Tests\TestCase;
@@ -12,7 +13,9 @@ class AbstractRequestTest extends TestCase
     public function setUp()
     {
         $this->request = m::mock('\Omnipay\Common\Message\AbstractRequest')->makePartial();
-        $this->request->initialize();
+        $this->request->initialize([
+            'currency' => 'USD',
+        ]);
     }
 
     /**
@@ -39,8 +42,8 @@ class AbstractRequestTest extends TestCase
 
     public function testInitializeWithParams()
     {
-        $this->assertSame($this->request, $this->request->initialize(array('amount' => '1.23')));
-        $this->assertSame('1.23', $this->request->getAmount());
+        $this->assertSame($this->request, $this->request->initialize(array('amount' => '123', 'currency' => 'USD')));
+        $this->assertSame('123', $this->request->getAmount()->getAmount());
     }
 
     /**
@@ -87,14 +90,14 @@ class AbstractRequestTest extends TestCase
 
     public function testAmount()
     {
-        $this->assertSame($this->request, $this->request->setAmount('2.00'));
-        $this->assertSame('2.00', $this->request->getAmount());
+        $this->assertSame($this->request, $this->request->setAmount(2));
+        $this->assertSame('2', $this->request->getAmount()->getAmount());
     }
 
-    public function testAmountWithFloat()
+    public function testAmountWithInt()
     {
-        $this->assertSame($this->request, $this->request->setAmount(2.0));
-        $this->assertSame('2.00', $this->request->getAmount());
+        $this->assertSame($this->request, $this->request->setAmount(2));
+        $this->assertSame('2', $this->request->getAmount()->getAmount());
     }
 
     public function testAmountWithEmpty()
@@ -105,14 +108,14 @@ class AbstractRequestTest extends TestCase
 
     public function testAmountZeroFloat()
     {
-        $this->assertSame($this->request, $this->request->setAmount(0.0));
-        $this->assertSame('0.00', $this->request->getAmount());
+        $this->assertSame($this->request, $this->request->setAmount(0));
+        $this->assertSame('0', $this->request->getAmount()->getAmount());
     }
 
     public function testAmountZeroString()
     {
-        $this->assertSame($this->request, $this->request->setAmount('0.000000'));
-        $this->assertSame('0.00', $this->request->getAmount());
+        $this->assertSame($this->request, $this->request->setAmount('0'));
+        $this->assertSame('0', $this->request->getAmount()->getAmount());
     }
 
     /**
@@ -122,175 +125,35 @@ class AbstractRequestTest extends TestCase
     public function testAmountZeroNotAllowed()
     {
         $this->changeProtectedProperty('zeroAmountAllowed', false);
-        $this->request->setAmount('0.00');
-        $this->request->getAmount();
-    }
-
-    // See https://github.com/thephpleague/omnipay-common/issues/69
-    public function testAmountPrecision()
-    {
-        // The default precision for PHP is 6 decimal places.
-        ini_set('precision', 6);
-        $this->assertSame($this->request, $this->request->setAmount('67.10'));
-        $this->assertSame('67.10', $this->request->getAmount());
-
-        // At 17 decimal places, 67.10 will echo as 67.09999...
-        // This is *why* PHP sets the default precision at 6.
-        ini_set('precision', 17);
-        $this->assertSame('67.10', $this->request->getAmount());
-
-        $this->assertSame($this->request, $this->request->setAmount('67.01'));
-        $this->assertSame('67.01', $this->request->getAmount());
-
-        $this->assertSame($this->request, $this->request->setAmount('0.10'));
-        $this->assertSame('0.10', $this->request->getAmount());
-
-        $this->assertSame($this->request, $this->request->setAmount('0.01'));
-        $this->assertSame('0.01', $this->request->getAmount());
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     *
-     * We still want to catch obvious fractions of the minor units that are
-     * not precision errors at a much lower level.
-     */
-    public function testAmountPrecisionTooHigh()
-    {
-        $this->assertSame($this->request, $this->request->setAmount('123.005'));
-        $this->assertSame('123.005', $this->request->getAmount());
-    }
-
-    public function testGetAmountNoDecimals()
-    {
-        $this->assertSame($this->request, $this->request->setCurrency('JPY'));
-        $this->assertSame($this->request, $this->request->setAmount('1366'));
-        $this->assertSame('1366', $this->request->getAmount());
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testGetAmountNoDecimalsRounding()
-    {
-        // There will not be any rounding; the amount is sent as requested or not at all.
-        $this->assertSame($this->request, $this->request->setAmount('136.5'));
-        $this->assertSame($this->request, $this->request->setCurrency('JPY'));
+        $this->request->setAmount('0');
         $this->request->getAmount();
     }
 
     /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
+     * @expectedException InvalidArgumentException
      */
-    public function testAmountWithIntThrowsException()
+    public function testAmountWithFloatStringThrowsException()
     {
-        // ambiguous value, avoid errors upgrading from v0.9
-        $this->assertSame($this->request, $this->request->setAmount(10));
+        $this->assertSame($this->request, $this->request->setAmount('10.00'));
         $this->request->getAmount();
     }
 
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testAmountWithIntStringThrowsException()
+    public function testGetAmountFormatted()
     {
-        // ambiguous value, avoid errors upgrading from v0.9
-        // Some currencies only take integers, so an integer (in a string) should be valid.
-        $this->assertSame($this->request, $this->request->setAmount('10'));
-        $this->request->getAmount();
-    }
-
-    public function testGetAmountInteger()
-    {
-        $this->assertSame($this->request, $this->request->setAmount('13.66'));
-        $this->assertSame(1366, $this->request->getAmountInteger());
-    }
-
-    public function testGetAmountIntegerNoDecimals()
-    {
-        $this->assertSame($this->request, $this->request->setCurrency('JPY'));
-        $this->assertSame($this->request, $this->request->setAmount('1366'));
-        $this->assertSame(1366, $this->request->getAmountInteger());
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testAmountThousandsSepThrowsException()
-    {
-        $this->assertSame($this->request, $this->request->setAmount('1,234.00'));
-        $this->request->getAmount();
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testAmountInvalidFormatThrowsException()
-    {
-        $this->assertSame($this->request, $this->request->setAmount('1.234.00'));
-        $this->request->getAmount();
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testAmountInvalidTypeThrowsException()
-    {
-        $this->assertSame($this->request, $this->request->setAmount(true));
-        $this->request->getAmount();
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testAmountNegativeStringThrowsException()
-    {
-        $this->assertSame($this->request, $this->request->setAmount('-123.00'));
-        $this->request->getAmount();
-    }
-
-    /**
-     * @expectedException Omnipay\Common\Exception\InvalidRequestException
-     */
-    public function testAmountNegativeFloatThrowsException()
-    {
-        $this->assertSame($this->request, $this->request->setAmount(-123.00));
-        $this->request->getAmount();
+        $this->assertSame($this->request, $this->request->setAmount(1366));
+        $this->assertSame('13.66', $this->request->getAmount()->getFormatted());
     }
 
     public function testCurrency()
     {
-        $this->assertSame($this->request, $this->request->setCurrency('USD'));
-        $this->assertSame('USD', $this->request->getCurrency());
+        $this->assertSame($this->request, $this->request->setCurrency('EUR')->setAmount(1));
+        $this->assertSame('EUR', $this->request->getAmount()->getCurrency()->getCode());
     }
 
-    public function testCurrencyLowercase()
+    public function testAmountWithCurrency()
     {
-        $this->assertSame($this->request, $this->request->setCurrency('usd'));
-        $this->assertSame('USD', $this->request->getCurrency());
-    }
-
-    public function testCurrencyNumeric()
-    {
-        $this->assertSame($this->request, $this->request->setCurrency('USD'));
-        $this->assertSame('840', $this->request->getCurrencyNumeric());
-    }
-
-    public function testCurrencyDecimals()
-    {
-        $this->assertSame($this->request, $this->request->setCurrency('JPY'));
-        $this->assertSame(0, $this->request->getCurrencyDecimalPlaces());
-    }
-
-    public function testFormatCurrency()
-    {
-        $this->assertSame('1234.00', $this->request->formatCurrency(1234));
-    }
-
-    public function testFormatCurrencyNoDecimals()
-    {
-        $this->request->setCurrency('JPY');
-        $this->assertSame('1234', $this->request->formatCurrency(1234));
+        $this->assertSame($this->request, $this->request->setCurrency('USD')->setAmount(new Amount(1, 'EUR')));
+        $this->assertSame('EUR', $this->request->getAmount()->getCurrency()->getCode());
     }
 
     public function testDescription()
@@ -388,6 +251,7 @@ class AbstractRequestTest extends TestCase
         $expected = array(
             'testMode' => true,
             'token' => 'asdf',
+            'currency' => 'USD',
         );
         $this->assertEquals($expected, $this->request->getParameters());
     }
@@ -401,7 +265,7 @@ class AbstractRequestTest extends TestCase
         $this->request = new AbstractRequestTest_MockAbstractRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->send();
 
-        $this->request->setCurrency('PHP');
+        $this->request->setAmount('100');
     }
 
     public function testCanValidateExistingParameters()
@@ -422,9 +286,9 @@ class AbstractRequestTest extends TestCase
         $this->request->validate('testMode', 'token');
     }
 
-    public function testNoCurrencyReturnedIfCurrencyNotSet()
+    public function testNoAmountReturnedIfAmountNotSet()
     {
-        $this->assertNull($this->request->getCurrencyNumeric());
+        $this->assertNull($this->request->getAmount());
     }
 
     public function testSend()


### PR DESCRIPTION
See https://github.com/thephpleague/omnipay/issues/322

Breaking change; input Amount parameter is now an integer (or string representing an integer), instead of a float.

Prevent rounding/converting issues. The `getAmountInteger` is removed (as this is the default now) and a new `getAmountFloat` is added, for the old behaviour. Omnipay users would need to update their code for this.

A Money object (from https://github.com/moneyphp/money) is allows for `setMoney()`, which then sets the amount/currency on the request.