### PR TITLE
Support for card present transactions

### DIFF
--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -56,6 +56,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * * startMonth
  * * startYear
  * * cvv
+ * * tracks
  * * issueNumber
  * * billingTitle
  * * billingName
@@ -542,6 +543,28 @@ class CreditCard
     public function setCvv($value)
     {
         return $this->setParameter('cvv', $value);
+    }
+
+    /**
+     * Get raw data for all tracks on the credit card magnetic strip.
+     *
+     * @return string
+     */
+    public function getTracks()
+    {
+        return $this->getParameter('tracks');
+    }
+
+    /**
+     * Sets raw data from all tracks on the credit card magnetic strip. Used by gateways that support card-present
+     * transactions.
+     *
+     * @param $value
+     * @return CreditCard
+     */
+    public function setTracks($value)
+    {
+        return $this->setParameter('tracks', $value);
     }
 
     /**

--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -556,6 +556,40 @@ class CreditCard
     }
 
     /**
+     * Get raw data for track 1 on the credit card magnetic strip.
+     *
+     * @return string
+     */
+    public function getTrack1()
+    {
+        $track1 = null;
+        if ($tracks = $this->getTracks()) {
+            $pattern = '/\%B\d{1,19}\^.{2,26}\^\d{4}\d*\?/';
+            if (preg_match($pattern, $tracks, $matches) === 1) {
+                $track1 = $matches[0];
+            }
+        }
+        return $track1;
+    }
+
+    /**
+     * Get raw data for track 2 on the credit card magnetic strip.
+     *
+     * @return string
+     */
+    public function getTrack2()
+    {
+        $track2 = null;
+        if ($tracks = $this->getTracks()) {
+            $pattern = '/;\d{1,19}=\d{4}\d*\?/';
+            if (preg_match($pattern, $tracks, $matches) === 1) {
+                $track2 = $matches[0];
+            }
+        }
+        return $track2;
+    }
+
+    /**
      * Sets raw data from all tracks on the credit card magnetic strip. Used by gateways that support card-present
      * transactions.
      *

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -6,6 +6,9 @@ use Omnipay\Tests\TestCase;
 
 class CreditCardTest extends TestCase
 {
+    /** @var CreditCard */
+    private $card;
+
     public function setUp()
     {
         $this->card = new CreditCard;
@@ -311,8 +314,22 @@ class CreditCardTest extends TestCase
 
     public function testTracks()
     {
-        $this->card->setTracks('%25B4242424242424242%5ETESTLAST%2FTESTFIRST%5E1505201425400714000000%3F%3B4242424242424242%3D150520142547140130%3F');
-        $this->assertSame('%25B4242424242424242%5ETESTLAST%2FTESTFIRST%5E1505201425400714000000%3F%3B4242424242424242%3D150520142547140130%3F', $this->card->getTracks());
+        $this->card->setTracks('%B4242424242424242^SMITH/JOHN ^1520126100000000000000444000000?;4242424242424242=15201269999944401?');
+        $this->assertSame('%B4242424242424242^SMITH/JOHN ^1520126100000000000000444000000?;4242424242424242=15201269999944401?', $this->card->getTracks());
+    }
+
+    public function testShouldReturnTrack1()
+    {
+        $this->card->setTracks('%B4242424242424242^SMITH/JOHN ^1520126100000000000000444000000?;4242424242424242=15201269999944401?');
+        $actual = $this->card->getTrack1();
+        $this->assertEquals('%B4242424242424242^SMITH/JOHN ^1520126100000000000000444000000?', $actual);
+    }
+
+    public function testShouldReturnTrack2()
+    {
+        $this->card->setTracks('%B4242424242424242^SMITH/JOHN ^1520126100000000000000444000000?;4242424242424242=15201269999944401?');
+        $actual = $this->card->getTrack2();
+        $this->assertEquals(';4242424242424242=15201269999944401?', $actual);
     }
 
     public function testIssueNumber()

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -309,6 +309,12 @@ class CreditCardTest extends TestCase
         $this->assertEquals('456', $this->card->getCvv());
     }
 
+    public function testTracks()
+    {
+        $this->card->setTracks('%25B4242424242424242%5ETESTLAST%2FTESTFIRST%5E1505201425400714000000%3F%3B4242424242424242%3D150520142547140130%3F');
+        $this->assertSame('%25B4242424242424242%5ETESTLAST%2FTESTFIRST%5E1505201425400714000000%3F%3B4242424242424242%3D150520142547140130%3F', $this->card->getTracks());
+    }
+
     public function testIssueNumber()
     {
         $this->card->setIssueNumber('12');


### PR DESCRIPTION
Authorize.Net and Stripe are examples of gateways that support card present transactions i.e. they accept raw track data from the credit card's magnetic strip. In order to support this, the `CreditCard` object needs a few tweaks to be able to store this track information.