### PR TITLE
Allow Symfony 3 HttpFoundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.3.2",
         "guzzle/guzzle": "~3.9",
-        "symfony/http-foundation": "~2.1"
+        "symfony/http-foundation": "~2.1|^3"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"


### PR DESCRIPTION
This allows apps/teams to move to Symfony3. Without it, upgrading is
impossible due to restrictions on using Http Foundation from 2.x series.

This is same PR as #97, but only has allowance of HttpFoundation from 3.x series, without extra jobs to run.

