### PR TITLE
Allow Symfony 3 HttpFoundation (with TravisCI builds)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,22 @@ sudo: false
 env:
   - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.1"
   - SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.1"
+  - SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.1"
   - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.*"
   - SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.*"
+  - SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+
+#Symfony 3 expects minimum PHP version of 5.5.9
+matrix:
+  exclude:
+    - env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.1"
+      php: 5.3
+    - env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.1"
+      php: 5.4
+    - env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+      php: 5.3
+    - env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+      php: 5.4
 
 before_script:
   - composer require symfony/http-foundation:${SYMFONY_VERSION} --no-update

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.3.2",
         "guzzle/guzzle": "~3.9",
-        "symfony/http-foundation": "~2.1"
+        "symfony/http-foundation": "~2.1|^3"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"


### PR DESCRIPTION
This allows apps/teams to move to Symfony3. Without it, upgrading is
impossible due to restrictions on using Http Foundation from 2.x series.

Updated TravisCI to run with Symfony 3.

This is same PR as #96 but has TravisCI run Symfony 3 for PHP >=5.5. 

We really need Symfony 3 allowed and wasn't sure if just allowing it was enough or if running extra builds on TravisCI is not something maintainers would prefer for just this small change.