### PR TITLE
Allow Symfony 3 + fix branch-alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,29 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
-
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-env:
-  - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.1"
-  - SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.1"
-  - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.*"
-  - SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.*"
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.3
+          env: SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.1"
+        - php: 5.4
+          env: SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.*"
+        - php: 5.5
+          env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+        - php: 5.6
+          env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+        - php: 7.0
+          env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+        - php: hhvm
+          env: SYMFONY_VERSION="3.*" GUZZLE_VERSION="3.*"
+
 
 before_script:
   - composer require symfony/http-foundation:${SYMFONY_VERSION} --no-update
   - composer require guzzle/guzzle:${GUZZLE_VERSION} --no-update
-  - composer install -n --dev --prefer-source
+  - composer install -n --prefer-source
 
 script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
     "require": {
         "php": ">=5.3.2",
         "guzzle/guzzle": "~3.9",
-        "symfony/http-foundation": "~2.1"
+        "symfony/http-foundation": "~2.1|~3.0"
     },
     "require-dev": {
         "omnipay/tests": "~2.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         },
         "gateways": [
             "AuthorizeNet_AIM",


### PR DESCRIPTION
* `symfony/http-foundation` version 3.* is BC with 2.*, so allowing it is nice (don't prevent Symfony 3 in projects)
* `branch-alias` was far beyond the current tags