### PR TITLE
Use cache, prefer-lowest/stable instead of specific versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,11 @@ matrix:
   include:
     - php: 5.3
       env: setup=lowest
-    - php: 5.3
-      env: setup=stable
     - php: 5.5
       env: setup=lowest
-    - php: 5.5
-      env: setup=stable
 
 install:
   - if [[ $setup = 'basic' ]]; then travis_retry composer install --prefer-dist --no-interaction; fi
-  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable; fi
   - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
-
 
 script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,30 @@ php:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-env:
-  - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.1"
-  - SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.1"
-  - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.*"
-  - SYMFONY_VERSION="2.*" GUZZLE_VERSION="3.*"
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
 
-before_script:
-  - composer require symfony/http-foundation:${SYMFONY_VERSION} --no-update
-  - composer require guzzle/guzzle:${GUZZLE_VERSION} --no-update
-  - composer install -n --dev --prefer-source
+env:
+  global:
+    - setup=basic
+
+matrix:
+  include:
+    - php: 5.3
+      env: setup=lowest
+    - php: 5.3
+      env: setup=stable
+    - php: 5.5
+      env: setup=lowest
+    - php: 5.5
+      env: setup=stable
+
+install:
+  - if [[ $setup = 'basic' ]]; then travis_retry composer install --prefer-dist --no-interaction; fi
+  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
+
 
 script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/http-foundation": "~2.1|~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "~2.0",
+        "squizlabs/php_codesniffer": "~1.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
- Use cache to improve speed
- Build lowest + stable builds for 5.3 (symfony2) and 5.5 (symfony3). 
- Normal builds for rest
- Reduces number of builds (24 -> 10) and build time