### PR TITLE
Fix bug where validating currency field passes after setting the currency to null

### DIFF
--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -399,7 +399,10 @@ abstract class AbstractRequest implements RequestInterface
      */
     public function setCurrency($value)
     {
-        return $this->setParameter('currency', strtoupper($value));
+        if ($value !== null) {
+            $value = strtoupper($value);
+        }
+        return $this->setParameter('currency', $value);
     }
 
     /**

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -284,6 +284,12 @@ class AbstractRequestTest extends TestCase
         $this->assertSame('USD', $this->request->getCurrency());
     }
 
+    public function testCurrencyNull()
+    {
+        $this->assertSame($this->request, $this->request->setCurrency(null));
+        $this->assertNull($this->request->getCurrency());
+    }
+
     public function testCurrencyNumeric()
     {
         $this->assertSame($this->request, $this->request->setCurrency('USD'));


### PR DESCRIPTION
Previously, if you set the currency field for a request to null via `AbstractRequest::setCurrency` or did not set it at all initially and then called `validate` on the currency field, the validation would pass because `strtoupper(null) === ''`, but `validate` looks for null values (via `isset`) when determining what should fail.

Now `strtoupper` is not called when the currency field is set to null, so the field is actually null instead of `''` and validation will fail appropriately.