### PR TITLE
Fix MasterCard "2" series BIN range support

### DIFF
--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -119,7 +119,7 @@ class CreditCard
      */
     protected $supported_cards = array(
         self::BRAND_VISA => '/^4\d{12}(\d{3})?$/',
-        self::BRAND_MASTERCARD => '/^(5[1-5]\d{4}|677189)\d{10}$|^(222[1-9]|2[3-6]\d{2}|27[0-1]\d|2720)\d{12}$/',
+        self::BRAND_MASTERCARD => '/^(5[1-5]\d{4}|677189)\d{10}$|^2(?:2(?:2[1-9]|[3-9]\d)|[3-6]\d\d|7(?:[01]\d|20))\d{12}$/',
         self::BRAND_DISCOVER => '/^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/',
         self::BRAND_AMEX => '/^3[47]\d{13}$/',
         self::BRAND_DINERS_CLUB => '/^3(0[0-5]|[68]\d)\d{11}$/',

--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -119,7 +119,8 @@ class CreditCard
      */
     protected $supported_cards = array(
         self::BRAND_VISA => '/^4\d{12}(\d{3})?$/',
-        self::BRAND_MASTERCARD => '/^(5[1-5]\d{4}|677189)\d{10}$|^2(?:2(?:2[1-9]|[3-9]\d)|[3-6]\d\d|7(?:[01]\d|20))\d{12}$/',
+        self::BRAND_MASTERCARD => '/^(5[1-5]\d{4}|677189)\d{10}$'.
+            '|^2(?:2(?:2[1-9]|[3-9]\d)|[3-6]\d\d|7(?:[01]\d|20))\d{12}$/',
         self::BRAND_DISCOVER => '/^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/',
         self::BRAND_AMEX => '/^3[47]\d{13}$/',
         self::BRAND_DINERS_CLUB => '/^3(0[0-5]|[68]\d)\d{11}$/',

--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -117,10 +117,10 @@ class CreditCard
      * @link https://github.com/Shopify/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb
      * @var array
      */
+    const REGEX_MASTERCARD = '/^(5[1-5]\d{4}|677189)\d{10}$|^2(?:2(?:2[1-9]|[3-9]\d)|[3-6]\d\d|7(?:[01]\d|20))\d{12}$/';
     protected $supported_cards = array(
         self::BRAND_VISA => '/^4\d{12}(\d{3})?$/',
-        self::BRAND_MASTERCARD => '/^(5[1-5]\d{4}|677189)\d{10}$'.
-            '|^2(?:2(?:2[1-9]|[3-9]\d)|[3-6]\d\d|7(?:[01]\d|20))\d{12}$/',
+        self::BRAND_MASTERCARD => self::REGEX_MASTERCARD,
         self::BRAND_DISCOVER => '/^(6011|65\d{2}|64[4-9]\d)\d{12}|(62\d{14})$/',
         self::BRAND_AMEX => '/^3[47]\d{13}$/',
         self::BRAND_DINERS_CLUB => '/^3(0[0-5]|[68]\d)\d{11}$/',

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -240,7 +240,9 @@ class CreditCardTest extends TestCase
     {
         $card = new CreditCard(array('number' => '5555555555554444'));
         $this->assertSame(CreditCard::BRAND_MASTERCARD, $card->getBrand());
-        $card = new CreditCard(array('number' => '2221000010000015'));
+        $card = new CreditCard(array('number' => '2230000010000006'));
+        $this->assertSame(CreditCard::BRAND_MASTERCARD, $card->getBrand());
+        $card = new CreditCard(array('number' => '6771890000000008'));
         $this->assertSame(CreditCard::BRAND_MASTERCARD, $card->getBrand());
     }
 


### PR DESCRIPTION
Improved coverage that fixes #87 (builds upon #88)

For example, card numbers starting with `22x` (where `x` was not 1 or 2, e.g. `2230 xxxx xxxx xxxx`) were not handled properly.

![regex_visualization](https://cloud.githubusercontent.com/assets/352182/17981551/6363e92c-6ac1-11e6-8a8f-22c089f8825e.jpg)

Updated test case to reflect the new coverage, as well as add missing test coverage for Mastercard 677189 BINs.

_(Thanks to @slashP for the notice, and @delatbabel for followup regex tests!)_