### PR TITLE
Alternative method checking in initialize

### DIFF
--- a/src/Omnipay/Common/Helper.php
+++ b/src/Omnipay/Common/Helper.php
@@ -6,6 +6,8 @@
 namespace Omnipay\Common;
 
 use InvalidArgumentException;
+use BadMethodCallException;
+use ReflectionClass;
 
 /**
  * Helper class
@@ -85,8 +87,8 @@ class Helper
                 $method = 'set'.ucfirst(static::camelCase($key));
                 try {
                     $target->$method($value);
-                } catch (\BadMethodCallException $e) {
-                    $targetRef = new \ReflectionClass($target);
+                } catch (BadMethodCallException $e) {
+                    $targetRef = new ReflectionClass($target);
                     $trace     = $e->getTrace();
                     if ($targetRef->getShortName() !== $trace[0]['class']) {
                         throw $e;

--- a/src/Omnipay/Common/Helper.php
+++ b/src/Omnipay/Common/Helper.php
@@ -87,7 +87,8 @@ class Helper
                     $target->$method($value);
                 } catch (\BadMethodCallException $e) {
                     $targetRef = new \ReflectionClass($target);
-                    if ($targetRef->getShortName() !== $e->getTrace()[0]['class']) {
+                    $trace     = $e->getTrace();
+                    if ($targetRef->getShortName() !== $trace[0]['class']) {
                         throw $e;
                     }
                 }

--- a/src/Omnipay/Common/Helper.php
+++ b/src/Omnipay/Common/Helper.php
@@ -83,7 +83,7 @@ class Helper
         if (is_array($parameters)) {
             foreach ($parameters as $key => $value) {
                 $method = 'set'.ucfirst(static::camelCase($key));
-                if (is_callable([$target, $method])) {
+                if (is_callable(array($target, $method))) {
                     $target->$method($value);
                 }
             }

--- a/src/Omnipay/Common/Helper.php
+++ b/src/Omnipay/Common/Helper.php
@@ -83,8 +83,13 @@ class Helper
         if (is_array($parameters)) {
             foreach ($parameters as $key => $value) {
                 $method = 'set'.ucfirst(static::camelCase($key));
-                if (is_callable(array($target, $method))) {
+                try {
                     $target->$method($value);
+                } catch (\BadMethodCallException $e) {
+                    $targetRef = new \ReflectionClass($target);
+                    if ($targetRef->getShortName() !== $e->getTrace()[0]['class']) {
+                        throw $e;
+                    }
                 }
             }
         }

--- a/src/Omnipay/Common/Helper.php
+++ b/src/Omnipay/Common/Helper.php
@@ -83,7 +83,7 @@ class Helper
         if (is_array($parameters)) {
             foreach ($parameters as $key => $value) {
                 $method = 'set'.ucfirst(static::camelCase($key));
-                if (method_exists($target, $method)) {
+                if (is_callable([$target, $method])) {
                     $target->$method($value);
                 }
             }


### PR DESCRIPTION
The method_exists function does not support __call magic method and returns false. The is_callable returns true when the __call is implemented.