### PR TITLE
Add Vindicia gateways to official gateways list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
             "TargetPay_Directebanking",
             "TargetPay_Ideal",
             "TargetPay_Mrcash",
+            "Vindicia",
+            "Vindicia_HOA",
+            "Vindicia_PayPal",
             "WorldPay"
         ]
     }


### PR DESCRIPTION
I've created some drivers for [Vindicia](http://www.vindicia.com) and would like to start the process of making these official Omnipay gateways.

Here's the repo: https://github.com/vimeo/omnipay-vindicia

Here's the PR to add it to the list of gateways: https://github.com/thephpleague/omnipay/pull/400

I'm opening this PR based on the instructions in omnipay/omnipay. Let me know what else I need to do to make this happen!