### PR TITLE
[3.0] Add HTTP Factories for Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
     "require": {
         "php": ">=5.6",
         "alcohol/iso4217": "^3.1",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "guzzlehttp/psr7": "^1.3"
     },
     "require-dev": {
         "omnipay/tests": "^3.0",
-        "guzzlehttp/guzzle": "^6.2.1",
-        "zendframework/zend-diactoros": "^1.1.0"
+        "guzzlehttp/guzzle": "^6.2.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Http/AbstractClient.php
+++ b/src/Http/AbstractClient.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace League\Omnipay\Common\Http;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Abstract Http Client
+ *
+ */
+abstract class AbstractClient implements ClientInterface
+{
+    /**
+     * @param  RequestInterface $request
+     * @return ResponseInterface
+     */
+    abstract public function sendRequest(RequestInterface $request);
+
+     /**
+      * Send a GET request.
+      *
+      * @param UriInterface|string $uri
+      * @param array $headers
+      * @return ResponseInterface
+      */
+    public function get($uri, $headers = [])
+    {
+        $request = Factory::createRequest('GET', $uri, $headers);
+
+        return $this->sendRequest($request);
+    }
+
+     /**
+      * Send a POST request.
+      *
+      * @param UriInterface|string $uri
+      * @param array $headers
+      * @param string|null|resource|StreamInterface $body
+      * @return ResponseInterface
+      */
+    public function post($uri, $headers = [], $body = null)
+    {
+        $request = Factory::createRequest('POST', $uri, $headers, $body);
+
+        return $this->sendRequest($request);
+    }
+
+     /**
+      * Send a PUT request.
+      *
+      * @param UriInterface|string $uri
+      * @param array $headers
+      * @param string|null|resource|StreamInterface $body
+      * @return ResponseInterface
+      */
+    public function put($uri, $headers = [], $body = null)
+    {
+        $request = Factory::createRequest('PUT', $uri, $headers, $body);
+
+        return $this->sendRequest($request);
+    }
+
+     /**
+      * Send a PATCH request.
+      *
+      * @param UriInterface|string $uri
+      * @param array $headers
+      * @param string|null|resource|StreamInterface $body
+      * @return ResponseInterface
+      */
+    public function patch($uri, $headers = [], $body = null)
+    {
+        $request = Factory::createRequest('PATCH', $uri, $headers, $body);
+
+        return $this->sendRequest($request);
+    }
+
+     /**
+      * Send a DELETE request.
+      *
+      * @param UriInterface|string $uri
+      * @param array $headers
+      * @param string|null|resource|StreamInterface $body
+      * @return ResponseInterface
+      */
+    public function delete($uri, $headers = [], $body = null)
+    {
+        $request = Factory::createRequest('DELETE', $uri, $headers, $body);
+
+        return $this->sendRequest($request);
+    }
+
+     /**
+      * Send a HEAD request.
+      *
+      * @param UriInterface|string $uri
+      * @param array $headers
+      * @return ResponseInterface
+      */
+    public function head($uri, $headers = [])
+    {
+        $request = Factory::createRequest('HEAD', $uri, $headers);
+
+        return $this->sendRequest($request);
+    }
+
+     /**
+      * Send a OPTIONS request.
+      *
+      * @param UriInterface|string $uri
+      * @return ResponseInterface
+      */
+    public function options($uri)
+    {
+        $request = Factory::createRequest('OPTIONS', $uri);
+
+        return $this->sendRequest($request);
+    }
+}

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -17,39 +17,74 @@ use Psr\Http\Message\UriInterface;
 interface ClientInterface
 {
     /**
-     * @param  string
-     * @param  string|UriInterface$uri
-     * @param  array $headers
-     * @param  string|resource|StreamInterface $body
-     * @return ResponseInterface
-     */
-    public function request($method, $uri, array $headers = [], $body = null);
-
-    /**
      * @param  RequestInterface $request
      * @return ResponseInterface
      */
     public function sendRequest(RequestInterface $request);
 
     /**
-     * @param  string $method
-     * @param  string|UriInterface $uri
-     * @param  array $headers
-     * @param  string|resource|StreamInterface $body
-     * @param  string $protocolVersion
-     * @return RequestInterface
+     * Send a GET request.
+     *
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @return ResponseInterface
      */
-    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1');
+    public function get($uri, $headers = []);
 
     /**
-     * @param  string|UriInterface $uri
-     * @return UriInterface
+     * Send a POST request.
+     *
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @param string|null|resource|StreamInterface $body
+     * @return ResponseInterface
      */
-    public function createUri($uri);
+    public function post($uri, $headers = [], $body = null);
 
     /**
-     * @param  mixed $body
-     * @return StreamInterface
+     * Send a PUT request.
+     *
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @param string|null|resource|StreamInterface $body
+     * @return ResponseInterface
      */
-    public function createStream($body);
+    public function put($uri, $headers = [], $body = null);
+
+    /**
+     * Send a PATCH request.
+     *
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @param string|null|resource|StreamInterface $body
+     * @return ResponseInterface
+     */
+    public function patch($uri, $headers = [], $body = null);
+
+    /**
+     * Send a DELETE request.
+     *
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @param string|null|resource|StreamInterface $body
+     * @return ResponseInterface
+     */
+    public function delete($uri, $headers = [], $body = null);
+
+    /**
+     * Send a HEAD request.
+     *
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @return ResponseInterface
+     */
+    public function head($uri, $headers = []);
+
+    /**
+     * Send a OPTIONS request.
+     *
+     * @param UriInterface|string $uri
+     * @return ResponseInterface
+     */
+    public function options($uri);
 }

--- a/src/Http/Factory.php
+++ b/src/Http/Factory.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace League\Omnipay\Common\Http;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\ServerRequest;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class Factory
+{
+    /**
+     * Create a new request.
+     *
+     * @param string $method
+     * @param UriInterface|string $uri
+     * @param array $headers
+     * @param string|null|resource|StreamInterface $body
+     * @param string $version
+     * @return RequestInterface
+     */
+    public static function createRequest($method, $uri, $headers = [], $body = null, $version = '1.1')
+    {
+        return new Request($method, $uri, $headers, $body, $version);
+    }
+
+    /**
+     * Create a new response.
+     *
+     * @param int $statusCode
+     * @param array $headers
+     * @param null $body
+     * @return ResponseInterface
+     *
+     */
+    public static function createResponse($statusCode = 200, $headers = [], $body = null)
+    {
+        return new Response($statusCode, $headers, $body);
+    }
+
+    /**
+     * Create a new server request from PHP globals.
+     *
+     * @return ServerRequestInterface
+     */
+    public static function createServerRequestFromGlobals()
+    {
+        return ServerRequest::fromGlobals();
+    }
+
+    /**
+     * Create a new URI.
+     *
+     * @param string|UriInterface $uri
+     *
+     * @return UriInterface
+     *
+     * @throws \InvalidArgumentException
+     *  If the given URI cannot be parsed.
+     */
+    public static function createUri($uri = '')
+    {
+        return \GuzzleHttp\Psr7\uri_for($uri);
+    }
+
+    /**
+     * Create a new stream from a resource.
+     *
+     * @param resource|string|null|int|float|bool|StreamInterface|callable $resource Entity body data
+     *
+     * @return StreamInterface
+     */
+    public static function createStream($resource = '')
+    {
+        return \GuzzleHttp\Psr7\stream_for($resource);
+    }
+}

--- a/src/Http/Factory.php
+++ b/src/Http/Factory.php
@@ -14,7 +14,21 @@ use Psr\Http\Message\UriInterface;
 class Factory
 {
     /**
-     * Create a new request.
+     * Create a new Response.
+     *
+     * @param int $statusCode
+     * @param array $headers
+     * @param null $body
+     * @return ResponseInterface
+     *
+     */
+    public static function createResponse($statusCode = 200, $headers = [], $body = null)
+    {
+        return new Response($statusCode, $headers, $body);
+    }
+
+    /**
+     * Create a new Request.
      *
      * @param string $method
      * @param UriInterface|string $uri
@@ -29,21 +43,20 @@ class Factory
     }
 
     /**
-     * Create a new response.
+     * Create a new ServerRequest.
      *
-     * @param int $statusCode
-     * @param array $headers
-     * @param null $body
-     * @return ResponseInterface
-     *
+     * @param string $method
+     * @param UriInterface|string $uri
+     * @param array $server
+     * @return ServerRequestInterface
      */
-    public static function createResponse($statusCode = 200, $headers = [], $body = null)
+    public static function createServerRequest($method, $uri, array $server = null)
     {
-        return new Response($statusCode, $headers, $body);
+        return new ServerRequest($method, $uri, [], null, '1.1', $server);
     }
 
     /**
-     * Create a new server request from PHP globals.
+     * Create a new ServerRequest from PHP globals.
      *
      * @return ServerRequestInterface
      */

--- a/src/Http/GuzzleClient.php
+++ b/src/Http/GuzzleClient.php
@@ -22,7 +22,7 @@ class GuzzleClient extends AbstractClient implements ClientInterface
 
     public function __construct(Client $client = null)
     {
-        $this->guzzle = $client ?: new Client(['a' => 'b']);
+        $this->guzzle = $client ?: new Client();
     }
 
     /**

--- a/src/Http/GuzzleClient.php
+++ b/src/Http/GuzzleClient.php
@@ -15,28 +15,14 @@ use Psr\Http\Message\UriInterface;
  * Implementation of the Http ClientInterface by using Guzzle.
  *
  */
-class GuzzleClient implements ClientInterface
+class GuzzleClient extends AbstractClient implements ClientInterface
 {
     /** @var  \GuzzleHttp\Client */
     protected $guzzle;
 
     public function __construct(Client $client = null)
     {
-        $this->guzzle = $client ?: new Client();
-    }
-
-    /**
-     * @param  string
-     * @param  string|UriInterface $uri
-     * @param  array $headers
-     * @param  string|resource|StreamInterface $body
-     * @return ResponseInterface
-     */
-    public function request($method, $uri, array $headers = [], $body = null)
-    {
-        $request = $this->createRequest($method, $uri, $headers, $body);
-
-        return $this->sendRequest($request);
+        $this->guzzle = $client ?: new Client(['a' => 'b']);
     }
 
     /**
@@ -46,36 +32,5 @@ class GuzzleClient implements ClientInterface
     public function sendRequest(RequestInterface $request)
     {
         return $this->guzzle->send($request);
-    }
-
-    /**
-     * @param  string $method
-     * @param  string|UriInterface $uri
-     * @param  array $headers
-     * @param  string|resource|StreamInterface $body
-     * @param  string $protocolVersion
-     * @return RequestInterface
-     */
-    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
-    {
-        return new Request($method, $uri, $headers, $body, $protocolVersion);
-    }
-
-    /**
-     * @param  string|UriInterface $uri
-     * @return UriInterface
-     */
-    public function createUri($uri)
-    {
-        return \GuzzleHttp\Psr7\uri_for($uri);
-    }
-
-    /**
-     * @param  mixed $resource
-     * @return StreamInterface
-     */
-    public function createStream($resource)
-    {
-        return \GuzzleHttp\Psr7\stream_for($resource);
     }
 }

--- a/src/Message/AbstractResponse.php
+++ b/src/Message/AbstractResponse.php
@@ -6,6 +6,7 @@
 namespace League\Omnipay\Common\Message;
 
 use League\Omnipay\Common\Exception\RuntimeException;
+use League\Omnipay\Common\Http\Factory;
 use Psr\Http\Message\ResponseInterface as HttpResponseInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\RedirectResponse;
@@ -202,7 +203,9 @@ abstract class AbstractResponse implements ResponseInterface
 
         /** @var $this RedirectResponseInterface */
         if ('GET' === $this->getRedirectMethod()) {
-            return new RedirectResponse($this->getRedirectUrl());
+            return Factory::createResponse(302, [
+                'location' => $this->getRedirectUrl(),
+            ]);
         } elseif ('POST' === $this->getRedirectMethod()) {
             $hiddenFields = '';
             foreach ($this->getRedirectData() as $key => $value) {
@@ -235,7 +238,9 @@ abstract class AbstractResponse implements ResponseInterface
                 $hiddenFields
             );
 
-            return new HtmlResponse($output);
+            return Factory::createResponse(200, [
+                'content-type' => 'text/html',
+            ], $output);
         }
 
         throw new RuntimeException('Invalid redirect method "'.$this->getRedirectMethod().'".');

--- a/tests/AbstractGatewayTest.php
+++ b/tests/AbstractGatewayTest.php
@@ -3,11 +3,11 @@
 namespace League\Omnipay\Common;
 
 use GuzzleHttp\Client;
+use League\Omnipay\Common\Http\Factory;
 use League\Omnipay\Common\Http\GuzzleClient;
 use Mockery as m;
 use League\Omnipay\Common\Message\AbstractRequest;
 use League\Omnipay\Tests\TestCase;
-use Zend\Diactoros\ServerRequestFactory;
 
 class AbstractGatewayTest extends TestCase
 {
@@ -20,7 +20,7 @@ class AbstractGatewayTest extends TestCase
     public function testConstruct()
     {
         $httpClient = new GuzzleClient(new Client());
-        $httpRequest = ServerRequestFactory::fromGlobals();
+        $httpRequest = Factory::createServerRequestFromGlobals();
         $this->gateway = new AbstractGatewayTest_MockAbstractGateway($httpClient, $httpRequest);
         $this->assertInstanceOf('\League\Omnipay\Common\Http\ClientInterface', $this->gateway->getProtectedHttpClient());
         $this->assertInstanceOf('\Psr\Http\Message\ServerRequestInterface', $this->gateway->getProtectedHttpRequest());
@@ -145,7 +145,7 @@ class AbstractGatewayTest extends TestCase
     public function testCreateRequest()
     {
         $httpClient = new GuzzleClient(new Client());
-        $httpRequest = ServerRequestFactory::fromGlobals();
+        $httpRequest = Factory::createServerRequestFromGlobals();
         $this->gateway = new AbstractGatewayTest_MockAbstractGateway($httpClient, $httpRequest);
         $request = $this->gateway->callCreateRequest(
             '\League\Omnipay\Common\AbstractGatewayTest_MockAbstractRequest',

--- a/tests/Http/AbstractClientTest.php
+++ b/tests/Http/AbstractClientTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace League\Omnipay\Common\Http;
+
+use Mockery as m;
+use League\Omnipay\Tests\TestCase;
+use GuzzleHttp\Client as Guzzle;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class AbstractClientTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->client = m::mock(AbstractClient::class)->makePartial();
+    }
+
+    public function testGet()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->get('https://thephpleague.com/'));
+    }
+
+    public function testPost()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->post('https://thephpleague.com/', [], 'my-body'));
+    }
+
+    public function testPut()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->put('https://thephpleague.com/', [], 'my-body'));
+    }
+
+    public function testPatch()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->patch('https://thephpleague.com/', [], 'my-body'));
+    }
+
+    public function testDelete()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->patch('https://thephpleague.com/', [], 'my-body'));
+    }
+
+    public function testHead()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->head('https://thephpleague.com/', []));
+    }
+
+    public function testOptions()
+    {
+        $response = m::mock(ResponseInterface::class);
+
+        $this->client->shouldReceive('sendRequest')->once()->andReturn($response);
+
+        $this->assertSame($response, $this->client->options('https://thephpleague.com/'));
+    }
+}

--- a/tests/Http/FactoryTest.php
+++ b/tests/Http/FactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace League\Omnipay\Common\Http;
+
+use Mockery as m;
+use League\Omnipay\Tests\TestCase;
+use GuzzleHttp\Client as Guzzle;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class FactoryTest extends TestCase
+{
+    public function testCreateRequest()
+    {
+        $request = Factory::createRequest('POST', 'https://thephpleague.com/', ['key' => 'value'], 'my-body');
+
+        $this->assertInstanceOf(RequestInterface::class, $request);
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('https://thephpleague.com/', $request->getUri());
+        $this->assertEquals('value', $request->getHeaderLine('key'));
+        $this->assertEquals('my-body', $request->getBody());
+    }
+
+    public function testCreateUri()
+    {
+        $uri = Factory::createUri('https://thephpleague.com/');
+
+        $this->assertInstanceOf(UriInterface::class, $uri);
+        $this->assertEquals('https://thephpleague.com/', (string) $uri);
+    }
+
+    public function testCreateStream()
+    {
+        $stream = Factory::createStream('my-body');
+
+        $this->assertInstanceOf(StreamInterface::class, $stream);
+        $this->assertEquals('my-body', (string) $stream);
+    }
+}

--- a/tests/Http/GuzzleClientTest.php
+++ b/tests/Http/GuzzleClientTest.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\UriInterface;
 
 class GuzzleClientTest extends TestCase
 {
+    /** @var  GuzzleClient */
+    protected $client;
+
     public function setUp()
     {
         $this->guzzle = m::mock(Guzzle::class)->makePartial();
@@ -42,51 +45,6 @@ class GuzzleClientTest extends TestCase
         $this->guzzle->shouldReceive('send')->once()->with($request)->andReturn($response);
 
         $this->assertSame($response, $this->client->sendRequest($request));
-    }
-
-    public function testCreateRequest()
-    {
-        $request = $this->client->createRequest('GET', 'https://thephpleague.com/', ['key' => 'value'], 'my-body');
-
-        $this->assertInstanceOf(RequestInterface::class, $request);
-        $this->assertEquals('GET', $request->getMethod());
-        $this->assertEquals('https://thephpleague.com/', $request->getUri());
-        $this->assertEquals('value', $request->getHeaderLine('key'));
-        $this->assertEquals('my-body', $request->getBody());
-    }
-
-    public function testCreateUri()
-    {
-        $uri = $this->client->createUri('https://thephpleague.com/');
-
-        $this->assertInstanceOf(UriInterface::class, $uri);
-        $this->assertEquals('https://thephpleague.com/', (string) $uri);
-    }
-
-    public function testCreateStream()
-    {
-        $stream = $this->client->createStream('my-body');
-
-        $this->assertInstanceOf(StreamInterface::class, $stream);
-        $this->assertEquals('my-body', (string) $stream);
-    }
-
-    public function getGet()
-    {
-        $response = m::mock(ResponseInterface::class);
-
-        $this->guzzle->shouldReceive('send')->once()->andReturn($response);
-
-        $this->assertSame($response, $this->client->get('https://thephpleague.com/'));
-    }
-
-    public function getPost()
-    {
-        $response = m::mock(ResponseInterface::class);
-
-        $this->guzzle->shouldReceive('send')->once()->andReturn($response);
-
-        $this->assertSame($response, $this->client->post('https://thephpleague.com/', [], 'my-body'));
     }
 }
 


### PR DESCRIPTION
- Since Guzzle supports ServerRequestFactory from Globals, we don't need to use Diactoros.
- The [HTTP Factory PSR](https://github.com/php-fig/fig-standards/blob/master/proposed/http-factory/http-factory.md) seems to be stalled, so I created my own factory with similar methods.
- The HttpClient should just be sending methods, not other PSR factories. So split those out.
- Add shortcuts for get/post/put etc in an AbstractClient, for easier upgrade and readability.
- Use static calls for the factories, as I don't think these need to be changed in user-land and don't require state.

I think this cleans up the factories pretty well, as we don't need to inject a lot of dependancies everywhere. Note that we do require on Guzzle/psr7 for this, but only internally, so we can upgrade to other PSR-7 factories when required.
