### PR TITLE
Fix return types on card date functions

### DIFF
--- a/src/Omnipay/Common/CreditCard.php
+++ b/src/Omnipay/Common/CreditCard.php
@@ -456,7 +456,7 @@ class CreditCard
     /**
      * Get the card expiry month.
      *
-     * @return string
+     * @return int
      */
     public function getExpiryMonth()
     {
@@ -477,7 +477,7 @@ class CreditCard
     /**
      * Get the card expiry year.
      *
-     * @return string
+     * @return int
      */
     public function getExpiryYear()
     {
@@ -531,7 +531,7 @@ class CreditCard
     /**
      * Get the card start year.
      *
-     * @return string
+     * @return int
      */
     public function getStartYear()
     {


### PR DESCRIPTION
They claim to return strings but actually return ints because the setters cast everything
