### PR TITLE
[3.0] Add convenience helpers, rename decoder, add tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     },
     "require-dev": {
         "omnipay/tests": "^3",
+        "php-http/mock-client": "^1",
         "squizlabs/php_codesniffer": "^2.8.1"
     },
     "extra": {

--- a/src/Omnipay/Common/Http/Client.php
+++ b/src/Omnipay/Common/Http/Client.php
@@ -35,10 +35,33 @@ class Client implements HttpClient, RequestFactory
      * @param array $headers
      * @param null $body
      * @param string $protocolVersion
+     * @return ResponseInterface
+     */
+    public function send($method, $uri, array $headers = null, $body = null, $protocolVersion = '1.1')
+    {
+        $request = $this->createRequest($method, $uri, $headers, $body, $protocolVersion);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * @param $method
+     * @param $uri
+     * @param array $headers
+     * @param null $body
+     * @param string $protocolVersion
      * @return RequestInterface
      */
-    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+    public function createRequest($method, $uri, array $headers = null, $body = null, $protocolVersion = '1.1')
     {
+        if (is_null($headers)) {
+            $headers = [];
+        }
+
+        if (is_array($body)) {
+            $body = http_build_query($body, '', '&');
+        }
+
         return $this->requestFactory->createRequest($method, $uri, $headers, $body, $protocolVersion);
     }
 
@@ -58,15 +81,13 @@ class Client implements HttpClient, RequestFactory
      * @param array $headers
      * @return ResponseInterface
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $headers = null)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'GET',
             $uri,
             $headers
         );
-
-        return $this->sendRequest($request);
     }
 
     /**
@@ -77,16 +98,14 @@ class Client implements HttpClient, RequestFactory
      * @param string|null|resource|StreamInterface $body
      * @return ResponseInterface
      */
-    public function post($uri, array $headers = [], $body = null)
+    public function post($uri, array $headers = null, $body = null)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'POST',
             $uri,
             $headers,
             $body
         );
-
-        return $this->sendRequest($request);
     }
 
     /**
@@ -97,16 +116,14 @@ class Client implements HttpClient, RequestFactory
      * @param string|null|resource|StreamInterface $body
      * @return ResponseInterface
      */
-    public function put($uri, array $headers = [], $body = null)
+    public function put($uri, array $headers = null, $body = null)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'PUT',
             $uri,
             $headers,
             $body
         );
-
-        return $this->sendRequest($request);
     }
 
     /**
@@ -117,16 +134,14 @@ class Client implements HttpClient, RequestFactory
      * @param string|null|resource|StreamInterface $body
      * @return ResponseInterface
      */
-    public function patch($uri, array $headers = [], $body = null)
+    public function patch($uri, array $headers = null, $body = null)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'PATCH',
             $uri,
             $headers,
             $body
         );
-
-        return $this->sendRequest($request);
     }
 
     /**
@@ -137,16 +152,14 @@ class Client implements HttpClient, RequestFactory
      * @param string|null|resource|StreamInterface $body
      * @return ResponseInterface
      */
-    public function delete($uri, array $headers = [], $body = null)
+    public function delete($uri, array $headers = null, $body = null)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'DELETE',
             $uri,
             $headers,
             $body
         );
-
-        return $this->sendRequest($request);
     }
 
     /**
@@ -156,15 +169,13 @@ class Client implements HttpClient, RequestFactory
      * @param array $headers
      * @return ResponseInterface
      */
-    public function head($uri, array $headers = [])
+    public function head($uri, array $headers = null)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'HEAD',
             $uri,
             $headers
         );
-
-        return $this->sendRequest($request);
     }
 
     /**
@@ -175,11 +186,9 @@ class Client implements HttpClient, RequestFactory
      */
     public function options($uri)
     {
-        $request = $this->createRequest(
+        return $this->send(
             'OPTIONS',
             $uri
         );
-
-        return $this->sendRequest($request);
     }
 }

--- a/src/Omnipay/Common/Http/Client.php
+++ b/src/Omnipay/Common/Http/Client.php
@@ -32,17 +32,13 @@ class Client implements HttpClient, RequestFactory
     /**
      * @param $method
      * @param $uri
-     * @param null|array $headers
+     * @param array $headers
      * @param string|array|resource|StreamInterface|null $body
      * @param string $protocolVersion
      * @return ResponseInterface
      */
-    public function send($method, $uri, array $headers = null, $body = null, $protocolVersion = '1.1')
+    public function send($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
     {
-        if (is_null($headers)) {
-            $headers = [];
-        }
-
         if (is_array($body)) {
             $body = http_build_query($body, '', '&');
         }
@@ -78,10 +74,10 @@ class Client implements HttpClient, RequestFactory
      * Send a GET request.
      *
      * @param UriInterface|string $uri
-     * @param null|array $headers
+     * @param array $headers
      * @return ResponseInterface
      */
-    public function get($uri, array $headers = null)
+    public function get($uri, array $headers = [])
     {
         return $this->send('GET', $uri, $headers);
     }
@@ -90,11 +86,11 @@ class Client implements HttpClient, RequestFactory
      * Send a POST request.
      *
      * @param UriInterface|string $uri
-     * @param null|array $headers
+     * @param array $headers
      * @param string|array|null|resource|StreamInterface $body
      * @return ResponseInterface
      */
-    public function post($uri, array $headers = null, $body = null)
+    public function post($uri, array $headers = [], $body = null)
     {
         return $this->send('POST', $uri, $headers, $body);
     }

--- a/src/Omnipay/Common/Http/Client.php
+++ b/src/Omnipay/Common/Http/Client.php
@@ -32,27 +32,12 @@ class Client implements HttpClient, RequestFactory
     /**
      * @param $method
      * @param $uri
-     * @param array $headers
-     * @param null $body
+     * @param null|array $headers
+     * @param string|array|resource|StreamInterface|null $body
      * @param string $protocolVersion
      * @return ResponseInterface
      */
     public function send($method, $uri, array $headers = null, $body = null, $protocolVersion = '1.1')
-    {
-        $request = $this->createRequest($method, $uri, $headers, $body, $protocolVersion);
-
-        return $this->sendRequest($request);
-    }
-
-    /**
-     * @param $method
-     * @param $uri
-     * @param array $headers
-     * @param null $body
-     * @param string $protocolVersion
-     * @return RequestInterface
-     */
-    public function createRequest($method, $uri, array $headers = null, $body = null, $protocolVersion = '1.1')
     {
         if (is_null($headers)) {
             $headers = [];
@@ -62,6 +47,21 @@ class Client implements HttpClient, RequestFactory
             $body = http_build_query($body, '', '&');
         }
 
+        $request = $this->createRequest($method, $uri, $headers, $body, $protocolVersion);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * @param $method
+     * @param $uri
+     * @param array $headers
+     * @param string|resource|StreamInterface|null $body
+     * @param string $protocolVersion
+     * @return RequestInterface
+     */
+    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+    {
         return $this->requestFactory->createRequest($method, $uri, $headers, $body, $protocolVersion);
     }
 
@@ -78,117 +78,24 @@ class Client implements HttpClient, RequestFactory
      * Send a GET request.
      *
      * @param UriInterface|string $uri
-     * @param array $headers
+     * @param null|array $headers
      * @return ResponseInterface
      */
     public function get($uri, array $headers = null)
     {
-        return $this->send(
-            'GET',
-            $uri,
-            $headers
-        );
+        return $this->send('GET', $uri, $headers);
     }
 
     /**
      * Send a POST request.
      *
      * @param UriInterface|string $uri
-     * @param array $headers
-     * @param string|null|resource|StreamInterface $body
+     * @param null|array $headers
+     * @param string|array|null|resource|StreamInterface $body
      * @return ResponseInterface
      */
     public function post($uri, array $headers = null, $body = null)
     {
-        return $this->send(
-            'POST',
-            $uri,
-            $headers,
-            $body
-        );
-    }
-
-    /**
-     * Send a PUT request.
-     *
-     * @param UriInterface|string $uri
-     * @param array $headers
-     * @param string|null|resource|StreamInterface $body
-     * @return ResponseInterface
-     */
-    public function put($uri, array $headers = null, $body = null)
-    {
-        return $this->send(
-            'PUT',
-            $uri,
-            $headers,
-            $body
-        );
-    }
-
-    /**
-     * Send a PATCH request.
-     *
-     * @param UriInterface|string $uri
-     * @param array $headers
-     * @param string|null|resource|StreamInterface $body
-     * @return ResponseInterface
-     */
-    public function patch($uri, array $headers = null, $body = null)
-    {
-        return $this->send(
-            'PATCH',
-            $uri,
-            $headers,
-            $body
-        );
-    }
-
-    /**
-     * Send a DELETE request.
-     *
-     * @param UriInterface|string $uri
-     * @param array $headers
-     * @param string|null|resource|StreamInterface $body
-     * @return ResponseInterface
-     */
-    public function delete($uri, array $headers = null, $body = null)
-    {
-        return $this->send(
-            'DELETE',
-            $uri,
-            $headers,
-            $body
-        );
-    }
-
-    /**
-     * Send a HEAD request.
-     *
-     * @param UriInterface|string $uri
-     * @param array $headers
-     * @return ResponseInterface
-     */
-    public function head($uri, array $headers = null)
-    {
-        return $this->send(
-            'HEAD',
-            $uri,
-            $headers
-        );
-    }
-
-    /**
-     * Send a OPTIONS request.
-     *
-     * @param UriInterface|string $uri
-     * @return ResponseInterface
-     */
-    public function options($uri)
-    {
-        return $this->send(
-            'OPTIONS',
-            $uri
-        );
+        return $this->send('POST', $uri, $headers, $body);
     }
 }

--- a/src/Omnipay/Common/Http/ResponseParser.php
+++ b/src/Omnipay/Common/Http/ResponseParser.php
@@ -5,7 +5,7 @@ namespace Omnipay\Common\Http;
 use Omnipay\Common\Exception\RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 
-class Decoder
+class ResponseParser
 {
     /**
      * @param string|ResponseInterface $response
@@ -39,6 +39,7 @@ class Decoder
         }
         return $data === null ? [] : $data;
     }
+
     /**
      * Parse the XML response body and return a \SimpleXMLElement.
      *

--- a/tests/Omnipay/Common/Http/ClientTest.php
+++ b/tests/Omnipay/Common/Http/ClientTest.php
@@ -51,27 +51,6 @@ class ClientTest extends TestCase
         $client->send('GET', '/path');
     }
 
-    public function testSendConvertsNullHeaders()
-    {
-        $mockClient = m::mock(HttpClient::class);
-        $mockFactory = m::mock(RequestFactory::class);
-        $client = new Client($mockClient, $mockFactory);
-
-        $request = new Request('POST', '/path', [], 'body');
-
-        $mockFactory->shouldReceive('createRequest')->withArgs([
-            'POST',
-            '/path',
-            [],
-            'body',
-            '1.1',
-        ])->andReturn($request);
-
-        $mockClient->shouldReceive('sendRequest')->with($request)->once();
-
-        $client->send('POST', '/path', null, 'body');
-    }
-
     public function testSendParsesArrayBody()
     {
         $mockClient = m::mock(HttpClient::class);
@@ -133,6 +112,6 @@ class ClientTest extends TestCase
 
         $mockClient->shouldReceive('sendRequest')->with($request)->once();
 
-        $client->post('/path', null, ['a' => 'b']);
+        $client->post('/path', [], ['a' => 'b']);
     }
 }

--- a/tests/Omnipay/Common/Http/ClientTest.php
+++ b/tests/Omnipay/Common/Http/ClientTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Omnipay\Common\Http;
+
+use Mockery as m;
+use GuzzleHttp\Psr7\Request;
+use Http\Client\HttpClient;
+use Http\Message\RequestFactory;
+use Omnipay\Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function testEmptyConstruct()
+    {
+        $client = new Client();
+
+        $this->assertAttributeInstanceOf(HttpClient::class, 'httpClient', $client);
+        $this->assertAttributeInstanceOf(RequestFactory::class, 'requestFactory', $client);
+    }
+
+    public function testCreateRequest()
+    {
+         $client = $this->getHttpClient();
+
+         $request = $client->createRequest('GET', '/path', ['foo' => 'bar']);
+
+         $this->assertInstanceOf(Request::class, $request);
+         $this->assertEquals('/path', $request->getUri());
+         $this->assertEquals(['bar'], $request->getHeader('foo'));
+    }
+
+    public function testCreateRequestNullHeaders()
+    {
+        $client = $this->getHttpClient();
+
+        $request = $client->createRequest('GET', '/path', null);
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertEquals([], $request->getHeaders());
+    }
+
+    public function testParsesArrayBody()
+    {
+        $client = $this->getHttpClient();
+
+        $request = $client->createRequest('GET', '/path', null, ['a'=>'1', 'b'=>2]);
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertEquals('a=1&b=2', (string) $request->getBody());
+    }
+
+    public function testSend()
+    {
+        $mockClient = m::mock(HttpClient::class);
+        $mockFactory = m::mock(RequestFactory::class);
+        $client = new Client($mockClient, $mockFactory);
+
+        $request = new Request('GET', '/path');
+
+        $mockFactory->shouldReceive('createRequest')->withArgs([
+            'GET',
+            '/path',
+            [],
+            null,
+            '1.1',
+        ])->andReturn($request);
+
+        $mockClient->shouldReceive('sendRequest')->with($request)->once();
+
+        $client->send('GET', '/path');
+    }
+
+    public function testGet()
+    {
+        $mockClient = m::mock(HttpClient::class);
+        $mockFactory = m::mock(RequestFactory::class);
+        $client = new Client($mockClient, $mockFactory);
+
+        $request = new Request('GET', '/path');
+
+        $mockFactory->shouldReceive('createRequest')->withArgs([
+            'GET',
+            '/path',
+            [],
+            null,
+            '1.1',
+        ])->andReturn($request);
+
+        $mockClient->shouldReceive('sendRequest')->with($request)->once();
+
+        $client->get('/path');
+    }
+
+    public function testPost()
+    {
+        $mockClient = m::mock(HttpClient::class);
+        $mockFactory = m::mock(RequestFactory::class);
+        $client = new Client($mockClient, $mockFactory);
+
+        $request = new Request('GET', '/path', [], 'a=b');
+
+        $mockFactory->shouldReceive('createRequest')->withArgs([
+            'POST',
+            '/path',
+            [],
+            'a=b',
+            '1.1',
+        ])->andReturn($request);
+
+        $mockClient->shouldReceive('sendRequest')->with($request)->once();
+
+        $client->post('/path', null, ['a' => 'b']);
+    }
+}

--- a/tests/Omnipay/Common/Http/ResponseParserTest.php
+++ b/tests/Omnipay/Common/Http/ResponseParserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Omnipay\Common\Http;
+
+use GuzzleHttp\Psr7\Response;
+use Omnipay\Common\Exception\RuntimeException;
+use Omnipay\Tests\TestCase;
+
+class ResponseParserTest extends TestCase
+{
+    public function testParsesXmlString()
+    {
+        $data = ResponseParser::xml('<Foo><Baz>Bar</Baz></Foo>');
+
+        $this->assertInstanceOf('SimpleXMLElement', $data);
+        $this->assertEquals('Bar', (string) $data->Baz);
+    }
+
+    public function testParsesXmlResponse()
+    {
+        $response = new Response(200, [], '<Foo><Baz>Bar</Baz></Foo>');
+
+        $data = ResponseParser::xml($response);
+
+        $this->assertInstanceOf('SimpleXMLElement', $data);
+        $this->assertEquals('Bar', (string) $data->Baz);
+    }
+
+    public function testParsesXmlResponseException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $response = new Response(200, [], 'FooBar');
+
+        ResponseParser::xml($response);
+    }
+
+    public function testParsesJsonString()
+    {
+        $data = ResponseParser::json('{"Baz":"Bar"}');
+
+        $this->assertEquals(array('Baz' => 'Bar'), $data);
+    }
+
+    public function testParsesJsonResponse()
+    {
+        $response = new Response(200, [], '{"Baz":"Bar"}');
+
+        $data = ResponseParser::json($response);
+
+        $this->assertEquals(array('Baz' => 'Bar'), $data);
+    }
+
+    public function testParsesJsonResponseException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $response = new Response(200, [], 'FooBar');
+
+        ResponseParser::json($response);
+    }
+
+}


### PR DESCRIPTION
Makes it easier to upgrade; `null` headers is allowed an body is converted by default.
Renamed the Decoder to ResponseParser.

Added some tests