### PR TITLE
Account for large amounts

### DIFF
--- a/src/Common/Message/AbstractRequest.php
+++ b/src/Common/Message/AbstractRequest.php
@@ -324,7 +324,8 @@ abstract class AbstractRequest implements RequestInterface
             }
 
             // Check for rounding that may occur if too many significant decimal digits are supplied.
-            $decimal_count = strlen(substr(strrchr(sprintf('%.8g', $amount), '.'), 1));
+            $str_value = rtrim(number_format($amount, 8, '.', ''), '0');
+            $decimal_count = strlen(substr(strrchr($str_value, '.'), 1));
             if ($decimal_count > $this->getCurrencyDecimalPlaces()) {
                 throw new InvalidRequestException('Amount precision is too high for currency.');
             }

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -149,6 +149,15 @@ class AbstractRequestTest extends TestCase
         $this->assertSame('0.01', $this->request->getAmount());
     }
 
+    // See https://github.com/thephpleague/omnipay-common/issues/143
+    public function testAmountPrecisionLargeNumbers()
+    {
+        $this->request->setCurrency('VND');
+
+        $this->assertSame($this->request, $this->request->setAmount('103500000'));
+        $this->assertSame('103500000', $this->request->getAmount());
+    }
+
     /**
      * @expectedException Omnipay\Common\Exception\InvalidRequestException
      *


### PR DESCRIPTION
See https://github.com/thephpleague/omnipay-common/issues/143

Eg. for large numbers, the rounding doesn't work (> 8 number before comma).

TOdo
- [x] Fix this