### PR TITLE
Add json/xml helpers

### DIFF
--- a/src/Common/Http/Client.php
+++ b/src/Common/Http/Client.php
@@ -42,7 +42,7 @@ class Client implements RequestFactory
     public function send($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
     {
         if (!is_null($body) && !is_string($body)) {
-            $body = $this->encodeFormData($body);
+            $body = Helper::formDataEncode($body);
         }
 
         $request = $this->createRequest($method, $uri, $headers, $body, $protocolVersion);
@@ -58,11 +58,11 @@ class Client implements RequestFactory
      * @param array $headers
      * @param array $data
      * @param string $protocolVersion
-     * @return mixed
+     * @return array
      */
     public function json($method, $uri, $headers = [], array $data = null, $protocolVersion = '1.1')
     {
-        $body = $this->encodeJson($data);
+        $body = Helper::jsonEncode($data);
 
         $request = $this->createRequest($method, $uri, $headers, $body, $protocolVersion);
 
@@ -78,7 +78,7 @@ class Client implements RequestFactory
 
         $response = $this->sendRequest($request);
 
-        return ResponseParser::json($response, true);
+        return Helper::jsonDecode($response, true) ?: [];
     }
 
     /**
@@ -94,7 +94,7 @@ class Client implements RequestFactory
     public function xml($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
     {
         if (!is_null($body) && !is_string($body)) {
-            $body = $this->encodeFormData($body);
+            $body = Helper::formDataEncode($body);
         }
 
         $request = $this->createRequest($method, $uri, $headers, $body, $protocolVersion);
@@ -106,7 +106,7 @@ class Client implements RequestFactory
 
         $response = $this->sendRequest($request);
 
-        return ResponseParser::xml($response);
+        return Helper::xmlDecode($response);
     }
 
     /**
@@ -154,21 +154,5 @@ class Client implements RequestFactory
     public function post($uri, array $headers = [], $body = null)
     {
         return $this->send('POST', $uri, $headers, $body);
-    }
-
-    protected function encodeFormData($data)
-    {
-        return http_build_query($data, '', '&');
-    }
-
-    protected function encodeJson($value)
-    {
-        $body = json_encode($value);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \InvalidArgumentException('json_decode error: ' . json_last_error_msg());
-        }
-
-        return $body;
     }
 }

--- a/src/Common/Http/Helper.php
+++ b/src/Common/Http/Helper.php
@@ -5,7 +5,7 @@ namespace Omnipay\Common\Http;
 use Omnipay\Common\Exception\RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 
-class ResponseParser
+class Helper
 {
     /**
      * @param string|ResponseInterface $response
@@ -21,13 +21,41 @@ class ResponseParser
     }
 
     /**
+     * @param $data
+     * @return string
+     */
+    public static function formDataEncode($data)
+    {
+        return http_build_query($data, '', '&');
+    }
+
+    /**
+     * @param  $value
+     * @param  int $options
+     * @param  int $depth
+     * @return string
+     */
+    public static function jsonEncode($value, $options = 0, $depth = 512)
+    {
+        $body = json_encode($value, $options, $depth);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException('json_decode error: ' . json_last_error_msg());
+        }
+
+        return $body;
+    }
+
+    /**
      * Decodes a JSON string,
      *
      * @param  string|ResponseInterface $response
      * @param  bool $assoc
+     * @param  int $depth
+     * @param  int $options
      * @return mixed
      */
-    public static function json($response, $assoc = false, $depth = 512, $options = 0)
+    public static function jsonDecode($response, $assoc = false, $depth = 512, $options = 0)
     {
         $json = self::toString($response);
 
@@ -36,7 +64,7 @@ class ResponseParser
             throw new \InvalidArgumentException('json_decode error: ' . json_last_error());
         }
 
-        return $data === null ? [] : $data;
+        return $data;
     }
 
     /**
@@ -55,7 +83,7 @@ class ResponseParser
      * @link http://websec.io/2012/08/27/Preventing-XXE-in-PHP.html
      *
      */
-    public static function xml($response)
+    public static function xmlDecode($response)
     {
         $body = self::toString($response);
 

--- a/src/Common/Http/ResponseParser.php
+++ b/src/Common/Http/ResponseParser.php
@@ -21,22 +21,19 @@ class ResponseParser
     }
 
     /**
-     * Parse the JSON response body and return an array
-     *
-     * Copied from Response->json() in Guzzle3 (copyright @mtdowling)
-     * @link https://github.com/guzzle/guzzle3/blob/v3.9.3/src/Guzzle/Http/Message/Response.php
+     * Decodes a JSON string,
      *
      * @param  string|ResponseInterface $response
-     * @throws RuntimeException if the response body is not in JSON format
-     * @return array|string|int|bool|float
+     * @param  bool $assoc
+     * @return mixed
      */
-    public static function json($response)
+    public static function json($response, $assoc = false, $depth = 512, $options = 0)
     {
-        $body = self::toString($response);
+        $json = self::toString($response);
 
-        $data = json_decode($body, true);
-        if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new RuntimeException('Unable to parse response body into JSON: ' . json_last_error());
+        $data = json_decode($json, $assoc, $depth, $options);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException('json_decode error: ' . json_last_error());
         }
 
         return $data === null ? [] : $data;
@@ -78,7 +75,7 @@ class ResponseParser
         libxml_disable_entity_loader($disableEntities);
 
         if ($errorMessage !== null) {
-            throw new RuntimeException('Unable to parse response body into XML: ' . $errorMessage);
+            throw new \InvalidArgumentException('SimpleXML error: ' . $errorMessage);
         }
 
         return $xml;

--- a/tests/Omnipay/Common/Http/ResponseParserTest.php
+++ b/tests/Omnipay/Common/Http/ResponseParserTest.php
@@ -3,14 +3,13 @@
 namespace Omnipay\Common\Http;
 
 use GuzzleHttp\Psr7\Response;
-use Omnipay\Common\Exception\RuntimeException;
 use Omnipay\Tests\TestCase;
 
 class ResponseParserTest extends TestCase
 {
     public function testParsesJsonString()
     {
-        $data = ResponseParser::json('{"Baz":"Bar"}');
+        $data = ResponseParser::json('{"Baz":"Bar"}', true);
 
         $this->assertEquals(array('Baz' => 'Bar'), $data);
     }
@@ -21,16 +20,25 @@ class ResponseParserTest extends TestCase
 
         $data = ResponseParser::json($response);
 
+        $this->assertEquals((object) array('Baz' => 'Bar'), $data);
+    }
+
+    public function testParsesJsonResponseAssoc()
+    {
+        $response = new Response(200, [], '{"Baz":"Bar"}');
+
+        $data = ResponseParser::json($response, true);
+
         $this->assertEquals(array('Baz' => 'Bar'), $data);
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Unable to parse response body into JSON: 4
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage json_decode error: 4
      */
     public function testParsesJsonResponseException()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $response = new Response(200, [], 'FooBar');
 
@@ -56,8 +64,8 @@ class ResponseParserTest extends TestCase
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Unable to parse response body into XML: String could not be parsed as XML
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage SimpleXML error: String could not be parsed as XML
      */
     public function testParsesXmlResponseException()
     {


### PR DESCRIPTION
This adds a `json` and `xml` helper method to the HttpClient, to make it easier to request/process json or xml feeds.
 - Json encodes the data to json before sending, and decodes the result to an array
 - Xml sends the body as string, (encodes arrays as form data), and decodes the XML.

The `Accept` and `Content-Type` are set by default when not set.

Note that this slightly changes the `ResponseParser::json()` method to be inline with the normal `json_decode` options, but perhaps these can be made private, because these helpers would make them not so much needed.