### PR TITLE
Add isPending() to ResponseInterface

### DIFF
--- a/src/Common/Message/ResponseInterface.php
+++ b/src/Common/Message/ResponseInterface.php
@@ -37,6 +37,13 @@ interface ResponseInterface extends MessageInterface
     public function isRedirect();
 
     /**
+     * Is the transaction unfinished/uncertain/not credited yet?
+     *
+     * @return boolean
+     */
+    public function isPending();
+
+    /**
      * Is the transaction cancelled by the user?
      *
      * @return boolean


### PR DESCRIPTION
There's a default implementation for `isPending()` in the `AbstractResponse` class like for `isCanceled()` but contrary to `isCanceled()`, `isPending()` is not yet in the `ResponseInterface`