### PR TITLE
Add Comments of return data type

### DIFF
--- a/src/Common/GatewayInterface.php
+++ b/src/Common/GatewayInterface.php
@@ -40,7 +40,6 @@ interface GatewayInterface
      * Get gateway display name
      *
      * This can be used by carts to get the display name for each gateway.
-     * 
      * @return string
      */
     public function getName();
@@ -50,7 +49,6 @@ interface GatewayInterface
      *
      * This name can be used with GatewayFactory as an alias of the gateway class,
      * to create new instances of this gateway.
-     * 
      * @return string
      */
     public function getShortName();
@@ -63,21 +61,18 @@ interface GatewayInterface
      *     'testMode' => false, // boolean variable
      *     'landingPage' => array('billing', 'login'), // enum variable, first item is default
      * );
-     * 
      * @return array
      */
     public function getDefaultParameters();
 
     /**
      * Initialize gateway with parameters
-     * 
      * @return $this
      */
     public function initialize(array $parameters = array());
 
     /**
      * Get all gateway parameters
-     *
      * @return array
      */
     public function getParameters();

--- a/src/Common/GatewayInterface.php
+++ b/src/Common/GatewayInterface.php
@@ -40,6 +40,8 @@ interface GatewayInterface
      * Get gateway display name
      *
      * This can be used by carts to get the display name for each gateway.
+     * 
+     * @return string
      */
     public function getName();
 
@@ -48,6 +50,8 @@ interface GatewayInterface
      *
      * This name can be used with GatewayFactory as an alias of the gateway class,
      * to create new instances of this gateway.
+     * 
+     * @return string
      */
     public function getShortName();
 
@@ -59,11 +63,15 @@ interface GatewayInterface
      *     'testMode' => false, // boolean variable
      *     'landingPage' => array('billing', 'login'), // enum variable, first item is default
      * );
+     * 
+     * @return array
      */
     public function getDefaultParameters();
 
     /**
      * Initialize gateway with parameters
+     * 
+     * @return $this
      */
     public function initialize(array $parameters = array());
 


### PR DESCRIPTION
 Add Comments of return data type on GatewayInterface so my IDE can hint me when I wrote code like `$gateway=new Omnipay('xxPayType'); $gateway->initialize($config)->someOperation($params);`