### PR TITLE
Clarify exception message for credit cards

### DIFF
--- a/src/Common/CreditCard.php
+++ b/src/Common/CreditCard.php
@@ -274,9 +274,15 @@ class CreditCard
      */
     public function validate()
     {
-        foreach (array('number', 'expiryMonth', 'expiryYear') as $key) {
+        $requiredParameters = array(
+            'number' => 'credit card number',
+            'expiryMonth' => 'expiration month',
+            'expiryYear' => 'expiration year'
+        );
+
+        foreach ($requiredParameters as $key => $val) {
             if (!$this->getParameter($key)) {
-                throw new InvalidCreditCardException("The $key parameter is required");
+                throw new InvalidCreditCardException("The $val is required");
             }
         }
 

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -57,7 +57,7 @@ class CreditCardTest extends TestCase
 
     /**
      * @expectedException \Omnipay\Common\Exception\InvalidCreditCardException
-     * @expectedExceptionMessage The number parameter is required
+     * @expectedExceptionMessage The credit card number is required
      */
     public function testValidateNumberRequired()
     {
@@ -67,7 +67,7 @@ class CreditCardTest extends TestCase
 
     /**
      * @expectedException \Omnipay\Common\Exception\InvalidCreditCardException
-     * @expectedExceptionMessage The expiryMonth parameter is required
+     * @expectedExceptionMessage The expiration month is required
      */
     public function testValidateExpiryMonthRequired()
     {
@@ -77,7 +77,7 @@ class CreditCardTest extends TestCase
 
     /**
      * @expectedException \Omnipay\Common\Exception\InvalidCreditCardException
-     * @expectedExceptionMessage The expiryYear parameter is required
+     * @expectedExceptionMessage The expiration year is required
      */
     public function testValidateExpiryYearRequired()
     {


### PR DESCRIPTION
When missing a required parameter for credit cards
the exception message uses the key value in the
array instead of a more standard value.

resolves #169 