### PR TITLE
Use of string currencies is deprecated

### DIFF
--- a/src/Common/Message/AbstractRequest.php
+++ b/src/Common/Message/AbstractRequest.php
@@ -330,7 +330,7 @@ abstract class AbstractRequest implements RequestInterface
                 throw new InvalidRequestException('Amount precision is too high for currency.');
             }
 
-            $money = $moneyParser->parse((string) $number, $currency->getCode());
+            $money = $moneyParser->parse((string) $number, $currency);
 
             // Check for a negative amount.
             if (!$this->negativeAmountAllowed && $money->isNegative()) {


### PR DESCRIPTION
Use of string currencies is deprecated and triggers an E_DEPRECATED error.
https://github.com/moneyphp/money/commit/0e33bf8d26796bf3d60d595172aaef6deae80ecc

[src/Parser/DecimalMoneyParser.php#L49](https://github.com/moneyphp/money/blob/master/src/Parser/DecimalMoneyParser.php#L49)
```php
/*
 * This conversion is only required whilst currency can be either a string or a
 * Currency object.
 */
$currency = $forceCurrency;
if (!$currency instanceof Currency) {
    @trigger_error('Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please pass a '.Currency::class.' instance instead.', E_USER_DEPRECATED);
    $currency = new Currency($currency);
}
```