### PR TITLE
Update renamed php-http/client-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "php": "^7.1",
-        "php-http/client-implementation": "^1",
+        "php-http/client-common": "^1",
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.2.1",
         "symfony/http-foundation": "^2.1|^3|^4",


### PR DESCRIPTION
php-http/client-implementation repository repository has been renamed to php-http/client-common.
Therefore, when updating the dependencies, an error occurs that it is not possible to find the package:
 omnipay/common requires php-http/client-implementation ^1 -> no matching package found.