### PR TITLE
Allow to set amount as integer

### DIFF
--- a/src/Common/Message/AbstractRequest.php
+++ b/src/Common/Message/AbstractRequest.php
@@ -305,7 +305,7 @@ abstract class AbstractRequest implements RequestInterface
     }
 
     /**
-     * @param  string|null $forceAmount
+     * @param  string|int|null $amount
      * @return null|Money
      * @throws InvalidRequestException
      */

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -197,6 +197,13 @@ class AbstractRequestTest extends TestCase
         $this->assertSame(1366, $this->request->getAmountInteger());
     }
 
+    public function testSetAmountInteger()
+    {
+        $this->assertSame($this->request, $this->request->setAmountInteger(1366));
+        $this->assertSame(1366, $this->request->getAmountInteger());
+        $this->assertSame('13.66', $this->request->getAmount());
+    }
+
     public function testGetAmountIntegerNoDecimals()
     {
         $this->assertSame($this->request, $this->request->setCurrency('JPY'));
@@ -408,6 +415,20 @@ class AbstractRequestTest extends TestCase
         $this->request->setToken('asdf');
 
         $this->assertNull($this->request->validate('testMode', 'token'));
+    }
+
+    public function testCanValidateAmount()
+    {
+        $this->request->setAmount('1.00');
+
+        $this->assertNull($this->request->validate('amount'));
+    }
+
+    public function testCanValidateAmountInteger()
+    {
+        $this->request->setAmountInteger(1);
+
+        $this->assertNull($this->request->validate('amount'));
     }
 
     /**

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -417,13 +417,6 @@ class AbstractRequestTest extends TestCase
         $this->assertNull($this->request->validate('testMode', 'token'));
     }
 
-    public function testCanValidateAmount()
-    {
-        $this->request->setAmount('1.00');
-
-        $this->assertNull($this->request->validate('amount'));
-    }
-
     public function testCanValidateAmountInteger()
     {
         $this->request->setAmountInteger(1);


### PR DESCRIPTION
This adds a method to set the amount as integer. Can be useful in case you're already using integer-based objects (eg. Money) instead of relying on the interfaces/objects directly (see https://github.com/thephpleague/omnipay-common/commit/cda8afc670d93e51d4a5d0676732206a230e5d4c which removed Money public support)