### PR TITLE
Allow PHP 5.6 and 7.0 to be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
 php:
+  - 5.6
+  - 7.0
   - 7.1
   - 7.2
 
@@ -20,10 +22,10 @@ env:
 
 matrix:
   include:
-    - php: 7.1
+    - php: 5.6
       env: setup=lowest symfony="^2.1"
-    - php: 7.1
-    - env: setup=lowest symfony="^3"
+    - php: 5.6
+      env: setup=lowest symfony="^3"
     - php: 7.1
       env: setup=lowest symfony="^4"
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "classmap": ["src/Omnipay.php"]
     },
     "require": {
-        "php": "^7.1",
+        "php": "^5.6|^7",
         "php-http/client-implementation": "^1",
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.2.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,6 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
-    </listeners>
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/Common/Http/Client.php
+++ b/src/Common/Http/Client.php
@@ -45,12 +45,12 @@ class Client implements ClientInterface
      * @throws \Http\Client\Exception
      */
     public function request(
-        string $method,
+        $method,
         $uri,
         array $headers = [],
         $body = null,
-        string $protocolVersion = '1.1'
-    ) : ResponseInterface {
+        $protocolVersion = '1.1'
+    ) {
         $request = $this->requestFactory->createRequest($method, $uri, $headers, $body, $protocolVersion);
 
         return $this->sendRequest($request);

--- a/src/Common/Http/ClientInterface.php
+++ b/src/Common/Http/ClientInterface.php
@@ -25,10 +25,10 @@ interface ClientInterface
      * @return ResponseInterface
      */
     public function request(
-        string $method,
+        $method,
         $uri,
         array $headers = [],
         $body = null,
-        string $protocolVersion = '1.1'
-    ) : ResponseInterface;
+        $protocolVersion = '1.1'
+    );
 }

--- a/src/Common/Http/Exception.php
+++ b/src/Common/Http/Exception.php
@@ -10,7 +10,7 @@ abstract class Exception extends \RuntimeException
     /** @var RequestInterface  */
     protected $request;
 
-    public function __construct($message, RequestInterface $request, Throwable $previous = null)
+    public function __construct($message, RequestInterface $request, $previous = null)
     {
         $this->request = $request;
 

--- a/src/Common/Http/Exception.php
+++ b/src/Common/Http/Exception.php
@@ -10,7 +10,7 @@ abstract class Exception extends \RuntimeException
     /** @var RequestInterface  */
     protected $request;
 
-    public function __construct(string $message, RequestInterface $request, Throwable $previous = null)
+    public function __construct($message, RequestInterface $request, Throwable $previous = null)
     {
         $this->request = $request;
 
@@ -24,7 +24,7 @@ abstract class Exception extends \RuntimeException
      *
      * @return RequestInterface
      */
-    public function getRequest(): RequestInterface
+    public function getRequest()
     {
         return $this->request;
     }


### PR DESCRIPTION
If this installs correctly, no need to use 7.1 while 5.6 is still on security support.