### PR TITLE
Accept Customer Object

### DIFF
--- a/src/Common/CreditCard.php
+++ b/src/Common/CreditCard.php
@@ -93,7 +93,9 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  */
 class CreditCard
 {
-    use ParametersTrait;
+    use ParametersTrait {
+        validate as traitValidate;
+    }
 
     const BRAND_VISA = 'visa';
     const BRAND_MASTERCARD = 'mastercard';
@@ -230,11 +232,21 @@ class CreditCard
      * Generally if you want to validate the credit card yourself with custom error
      * messages, you should use your framework's validation library, not this method.
      *
+     * @param array $args
      * @return void
      * @throws Exception\InvalidRequestException
      * @throws InvalidCreditCardException
      */
-    public function validate()
+    public function validate(...$args)
+    {
+        if (!empty($args)) {
+            $this->traitValidate(...$args);
+        } else {
+            $this->validateCreditcard();
+        }
+    }
+
+    private function validateCreditcard()
     {
         $requiredParameters = array(
             'number' => 'credit card number',

--- a/src/Common/Message/AbstractRequest.php
+++ b/src/Common/Message/AbstractRequest.php
@@ -207,6 +207,31 @@ abstract class AbstractRequest implements RequestInterface
     }
 
     /**
+     * Get the customer object.
+     *
+     * @return CreditCard
+     */
+    public function getCustomer()
+    {
+        return $this->getParameter('card');
+    }
+
+    /**
+     * Sets the customer object.
+     *
+     * @param CreditCard $value
+     * @return $this
+     */
+    public function setCustomer($value)
+    {
+        if ($value && !$value instanceof CreditCard) {
+            $value = new CreditCard($value);
+        }
+
+        return $this->setParameter('card', $value);
+    }
+
+    /**
      * Get the card token.
      *
      * @return string

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -138,6 +138,23 @@ class CreditCardTest extends TestCase
         $this->assertFalse($this->card->addSupportedBrand('omniexpress', '/^9\d{12}(\d{3})?$/'));
     }
 
+    /**
+     * @expectedException  \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage The title parameter is required
+     */
+    public function testValidateTitle()
+    {
+        $this->card->validate('title');
+    }
+
+    /**
+     * @expectedException  \Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function testValidateMultiple()
+    {
+        $this->card->validate('title', 'gender');
+    }
+
     public function testTitle()
     {
         $this->card->setTitle('Mr.');

--- a/tests/Omnipay/Common/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Common/Message/AbstractRequestTest.php
@@ -78,6 +78,25 @@ class AbstractRequestTest extends TestCase
         $this->assertSame('1234', $card->getNumber());
     }
 
+    public function testCustomer()
+    {
+        // no type checking on card parameter
+        $card = new CreditCard;
+        $this->assertSame($this->request, $this->request->setCustomer($card));
+        $this->assertSame($card, $this->request->getCustomer());
+    }
+
+    public function testSetCustomerWithArray()
+    {
+        // passing array should create CreditCard object
+        $this->assertSame($this->request, $this->request->setCustomer(array('first_name' => 'Barry')));
+
+        $customer = $this->request->getCustomer();
+        $customer->validate('billingFirstName');
+        $this->assertInstanceOf('\Omnipay\Common\CreditCard', $customer);
+        $this->assertSame('Barry', $customer->getName());
+    }
+
     public function testToken()
     {
         $this->assertSame($this->request, $this->request->setToken('12345'));


### PR DESCRIPTION
This is mostly cosmetic:
 - Allows to easy validate parameters like the other objects with parameters
 - Allows to name the array/method 'customer' instead of 'card' in both the gateway and for the developers. Same behavior, same object, just a different name.