### PR TITLE
Added not found exception

### DIFF
--- a/src/Common/Exception/NotFoundException.php
+++ b/src/Common/Exception/NotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Omnipay\Common\Exception;
+
+/**
+ * Not Found Exception
+ *
+ * Thrown when the requested resource is not found on payment gateway
+ */
+class NotFoundException extends \Exception implements OmnipayException
+{
+    public function __construct($message = "Resource not found on payment gateway", $code = 404, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
Thrown when the requested resource is not found on payment gateway to differentiate from other invalid responses