### PR TITLE
"php-http/client-implementation ^1 -> no matching package found" fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "php-http/client-implementation": "^1",
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.2.1",
+        "php-http/guzzle6-adapter": "^1.1",
         "symfony/http-foundation": "^2.1|^3|^4",
         "moneyphp/money": "^3.1"
     },


### PR DESCRIPTION
Get rid of `- omnipay/common v3.0.2 requires php-http/client-implementation ^1 -> no matching package found.` error during composer installation