### PR TITLE
Add supportsFetchTransaction, fetchTransaction, and acceptNotification methods

### DIFF
--- a/src/Common/AbstractGateway.php
+++ b/src/Common/AbstractGateway.php
@@ -196,6 +196,16 @@ abstract class AbstractGateway implements GatewayInterface
     }
 
     /**
+     * Supports Fetch Transaction
+     *
+     * @return boolean True if this gateway supports the fetchTransaction() method
+     */
+    public function supportsFetchTransaction()
+    {
+        return method_exists($this, 'fetchTransaction');
+    }
+
+    /**
      * Supports Refund
      *
      * @return boolean True if this gateway supports the refund() method

--- a/src/Common/GatewayInterface.php
+++ b/src/Common/GatewayInterface.php
@@ -13,27 +13,31 @@ namespace Omnipay\Common;
  *
  * @see AbstractGateway
  *
- * @method \Omnipay\Common\Message\RequestInterface authorize(array $options = array())         (Optional method)
+ * @method \Omnipay\Common\Message\NotificationInterface acceptNotification(array $options = array()) (Optional method)
+ *         Receive and handle an instant payment notification (IPN)
+ * @method \Omnipay\Common\Message\RequestInterface authorize(array $options = array())               (Optional method)
  *         Authorize an amount on the customers card
- * @method \Omnipay\Common\Message\RequestInterface completeAuthorize(array $options = array()) (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface completeAuthorize(array $options = array())       (Optional method)
  *         Handle return from off-site gateways after authorization
- * @method \Omnipay\Common\Message\RequestInterface capture(array $options = array())           (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface capture(array $options = array())                 (Optional method)
  *         Capture an amount you have previously authorized
- * @method \Omnipay\Common\Message\RequestInterface purchase(array $options = array())          (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface purchase(array $options = array())                (Optional method)
  *         Authorize and immediately capture an amount on the customers card
- * @method \Omnipay\Common\Message\RequestInterface completePurchase(array $options = array())  (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface completePurchase(array $options = array())        (Optional method)
  *         Handle return from off-site gateways after purchase
- * @method \Omnipay\Common\Message\RequestInterface refund(array $options = array())            (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface refund(array $options = array())                  (Optional method)
  *         Refund an already processed transaction
- * @method \Omnipay\Common\Message\RequestInterface void(array $options = array())              (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface fetchTransaction(array $options = [])             (Optional method)
+ *         Fetches transaction information
+ * @method \Omnipay\Common\Message\RequestInterface void(array $options = array())                    (Optional method)
  *         Generally can only be called up to 24 hours after submitting a transaction
- * @method \Omnipay\Common\Message\RequestInterface createCard(array $options = array())        (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface createCard(array $options = array())              (Optional method)
  *         The returned response object includes a cardReference, which can be used for future transactions
- * @method \Omnipay\Common\Message\RequestInterface updateCard(array $options = array())        (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface updateCard(array $options = array())              (Optional method)
  *         Update a stored card
- * @method \Omnipay\Common\Message\RequestInterface deleteCard(array $options = array())        (Optional method)
+ * @method \Omnipay\Common\Message\RequestInterface deleteCard(array $options = array())              (Optional method)
  *         Delete a stored card
-*/
+ */
 interface GatewayInterface
 {
     /**

--- a/tests/Omnipay/Common/AbstractGatewayTest.php
+++ b/tests/Omnipay/Common/AbstractGatewayTest.php
@@ -109,6 +109,11 @@ class AbstractGatewayTest extends TestCase
         $this->assertFalse($this->gateway->supportsCompletePurchase());
     }
 
+    public function testSupportsFetchTransaction()
+    {
+        $this->assertFalse($this->gateway->supportsFetchTransaction());
+    }
+
     public function testSupportsRefund()
     {
         $this->assertFalse($this->gateway->supportsRefund());


### PR DESCRIPTION
Hi!

`AbstractGateway` has a `supportsAcceptNotification()` method, but `acceptNotification()` is not in the interface as optional method. Not sure if this is on purpose, but I feel like it should be there.

And as far as I can tell, `fetchTransaction()` is normally used to fetch transaction info, but it's not currently in the interface / AbstractGateway either.