### PR TITLE
Change client-implementation to client-common.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require": {
         "php": "^5.6|^7",
-        "php-http/client-implementation": "^1",
+        "php-http/client-common": "^1",
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.2.1",
         "symfony/http-foundation": "^2.1|^3|^4",


### PR DESCRIPTION
Change php-http/client-implementation to php-http/client-common
because that package changed it's name.

This will solve issue:
composer missing dep: php-http/client-implementation ^1 #197

And composer is again able to install omnipay-common again.

Would you please be so kind to accept this pull request?

Thanks,
Noud