### PR TITLE
Implement PSR-17 + PSR-18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -24,9 +22,9 @@ env:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: setup=lowest symfony="^2.1"
-    - php: 5.6
+    - php: 7.1
       env: setup=lowest symfony="^3"
     - php: 7.1
       env: setup=lowest symfony="^4"

--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,14 @@
         "classmap": ["src/Omnipay.php"]
     },
     "require": {
-        "php": "^5.6|^7",
-        "php-http/client-implementation": "^1",
-        "php-http/message": "^1.5",
-        "php-http/discovery": "^1.2.1",
+        "php": "^7.1",
+        "moneyphp/money": "^3.1",
+        "php-http/discovery": "^1.3",
+        "psr/http-client": "^1",
+        "psr/http-client-implementation": "^1",
+        "psr/http-factory": "^1",
         "symfony/http-foundation": "^2.1||^3||^4",
-        "moneyphp/money": "^3.1"
+        "zendframework/zend-diactoros": "^2.1"
     },
     "require-dev": {
         "omnipay/tests": "^3",
@@ -53,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "3.1.x-dev"
         }
     },
     "suggest": {

--- a/src/Common/Http/Client.php
+++ b/src/Common/Http/Client.php
@@ -2,37 +2,34 @@
 
 namespace Omnipay\Common\Http;
 
-use function GuzzleHttp\Psr7\str;
-use Http\Client\HttpClient;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery;
-use Http\Message\RequestFactory;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Omnipay\Common\Http\Exception\NetworkException;
 use Omnipay\Common\Http\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\UriInterface;
+use Psr\Http\Client\ClientInterface as Psr18ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface as Psr17RequestFactoryInterface;
 
-class Client implements ClientInterface
+final class Client implements ClientInterface
 {
     /**
      * The Http Client which implements `public function sendRequest(RequestInterface $request)`
-     * Note: Will be changed to PSR-18 when released
      *
-     * @var HttpClient
+     * @var Psr18ClientInterface
      */
     private $httpClient;
 
     /**
-     * @var RequestFactory
+     * @var Psr17RequestFactoryInterface
      */
     private $requestFactory;
 
-    public function __construct($httpClient = null, RequestFactory $requestFactory = null)
+    public function __construct($httpClient = null, $requestFactory = null)
     {
-        $this->httpClient = $httpClient ?: HttpClientDiscovery::find();
-        $this->requestFactory = $requestFactory ?: MessageFactoryDiscovery::find();
+        $this->httpClient = $httpClient ?: Psr18ClientDiscovery::find();
+        $this->requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
     }
 
     /**
@@ -51,7 +48,17 @@ class Client implements ClientInterface
         $body = null,
         $protocolVersion = '1.1'
     ) {
-        $request = $this->requestFactory->createRequest($method, $uri, $headers, $body, $protocolVersion);
+        $request = $this->requestFactory
+            ->createRequest($method, $uri)
+            ->withProtocolVersion($protocolVersion);
+
+        if ($body) {
+            $request = $request->withBody($body);
+        }
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
 
         return $this->sendRequest($request);
     }
@@ -59,7 +66,7 @@ class Client implements ClientInterface
     /**
      * @param RequestInterface $request
      * @return ResponseInterface
-     * @throws \Http\Client\Exception
+     * @throws NetworkException|RequestException
      */
     private function sendRequest(RequestInterface $request)
     {
@@ -67,7 +74,7 @@ class Client implements ClientInterface
             return $this->httpClient->sendRequest($request);
         } catch (\Http\Client\Exception\NetworkException $networkException) {
             throw new NetworkException($networkException->getMessage(), $request, $networkException);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             throw new RequestException($exception->getMessage(), $request, $exception);
         }
     }

--- a/tests/Omnipay/Common/Http/ClientTest.php
+++ b/tests/Omnipay/Common/Http/ClientTest.php
@@ -6,10 +6,10 @@ use GuzzleHttp\Psr7\Response;
 use Http\Client\Exception\NetworkException;
 use Mockery as m;
 use GuzzleHttp\Psr7\Request;
-use Http\Client\HttpClient;
-use Http\Message\RequestFactory;
 use Omnipay\Common\Http\Exception\RequestException;
 use Omnipay\Tests\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 
 class ClientTest extends TestCase
 {
@@ -17,14 +17,14 @@ class ClientTest extends TestCase
     {
         $client = new Client();
 
-        $this->assertAttributeInstanceOf(HttpClient::class, 'httpClient', $client);
-        $this->assertAttributeInstanceOf(RequestFactory::class, 'requestFactory', $client);
+        $this->assertAttributeInstanceOf(ClientInterface::class, 'httpClient', $client);
+        $this->assertAttributeInstanceOf(RequestFactoryInterface::class, 'requestFactory', $client);
     }
 
     public function testSend()
     {
-        $mockClient = m::mock(HttpClient::class);
-        $mockFactory = m::mock(RequestFactory::class);
+        $mockClient = m::mock(ClientInterface::class);
+        $mockFactory = m::mock(RequestFactoryInterface::class);
         $client = new Client($mockClient, $mockFactory);
 
         $request = new Request('GET', '/path');
@@ -33,9 +33,6 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
-            [],
-            null,
-            '1.1',
         ])->andReturn($request);
 
         $mockClient->shouldReceive('sendRequest')
@@ -49,8 +46,8 @@ class ClientTest extends TestCase
 
     public function testSendException()
     {
-        $mockClient = m::mock(HttpClient::class);
-        $mockFactory = m::mock(RequestFactory::class);
+        $mockClient = m::mock(ClientInterface::class);
+        $mockFactory = m::mock(RequestFactoryInterface::class);
         $client = new Client($mockClient, $mockFactory);
 
         $request = new Request('GET', '/path');
@@ -59,9 +56,6 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
-            [],
-            null,
-            '1.1',
         ])->andReturn($request);
 
         $mockClient->shouldReceive('sendRequest')
@@ -76,8 +70,8 @@ class ClientTest extends TestCase
 
     public function testSendNetworkException()
     {
-        $mockClient = m::mock(HttpClient::class);
-        $mockFactory = m::mock(RequestFactory::class);
+        $mockClient = m::mock(ClientInterface::class);
+        $mockFactory = m::mock(RequestFactoryInterface::class);
         $client = new Client($mockClient, $mockFactory);
 
         $request = new Request('GET', '/path');
@@ -86,9 +80,6 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
-            [],
-            null,
-            '1.1',
         ])->andReturn($request);
 
         $mockClient->shouldReceive('sendRequest')
@@ -103,8 +94,8 @@ class ClientTest extends TestCase
 
     public function testSendExceptionGetRequest()
     {
-        $mockClient = m::mock(HttpClient::class);
-        $mockFactory = m::mock(RequestFactory::class);
+        $mockClient = m::mock(ClientInterface::class);
+        $mockFactory = m::mock(RequestFactoryInterface::class);
         $client = new Client($mockClient, $mockFactory);
 
         $request = new Request('GET', '/path');
@@ -113,9 +104,6 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
-            [],
-            null,
-            '1.1',
         ])->andReturn($request);
 
         $exception = new \Exception('Something went wrong');


### PR DESCRIPTION
See https://github.com/thephpleague/omnipay-common/issues/204#issuecomment-474738658

 - Diactoros is requires as Guzzle/psr7 doesn't yet provide a PSR-17 request factory

Slightly breaking changes:
 - Client is now final
 - Typehint is removed for the request factory
 - Minimum PHP version is 7.1
 - A PSR-18 client is now required, but most php-http adapters should also support that now.

This should only affect people who are extending our Client. If they are providing a PSR-18/Httplug Client it should still work. Also the Requestfactory should support both the Httplug Requestfactory (deprecated) and PSR-17 RequestFactory.