### PR TITLE
Non-breaking PSR-17 + 18 compatibility in Http\Client 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,11 @@
         "php": "^7.1",
         "moneyphp/money": "^3.1",
         "php-http/discovery": "^1.6",
+        "php-http/message": "^1.5",
         "psr/http-client": "^1",
         "psr/http-client-implementation": "^1",
         "psr/http-factory": "^1",
-        "symfony/http-foundation": "^2.1||^3||^4",
-        "zendframework/zend-diactoros": "^2.1"
+        "symfony/http-foundation": "^2.1||^3||^4"
     },
     "require-dev": {
         "omnipay/tests": "^3",

--- a/src/Common/Http/Client.php
+++ b/src/Common/Http/Client.php
@@ -2,34 +2,63 @@
 
 namespace Omnipay\Common\Http;
 
-use Http\Discovery\Psr17FactoryDiscovery;
-use Http\Discovery\Psr18ClientDiscovery;
 use Omnipay\Common\Http\Exception\NetworkException;
 use Omnipay\Common\Http\Exception\RequestException;
+use Http\Client\HttpClient;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Exception\NotFoundException as DiscoveryNotFoundException;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
+use Http\Message\RequestFactory;
+use Psr\Http\Message\RequestFactoryInterface as Psr17RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Client\ClientInterface as Psr18ClientInterface;
-use Psr\Http\Message\RequestFactoryInterface as Psr17RequestFactoryInterface;
 
-final class Client implements ClientInterface
+class Client implements ClientInterface
 {
     /**
      * The Http Client which implements `public function sendRequest(RequestInterface $request)`
      *
-     * @var Psr18ClientInterface
+     * @var Psr18ClientInterface|HttpClient
      */
     private $httpClient;
 
     /**
-     * @var Psr17RequestFactoryInterface
+     * @var Psr17RequestFactoryInterface|RequestFactory
      */
     private $requestFactory;
 
     public function __construct($httpClient = null, $requestFactory = null)
     {
-        $this->httpClient = $httpClient ?: Psr18ClientDiscovery::find();
-        $this->requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+    }
+
+    protected function getHttpClient()
+    {
+        if (empty($this->httpClient)) {
+            try {
+                $this->httpClient = Psr18ClientDiscovery::find();
+            } catch (DiscoveryNotFoundException $e) {
+                $this->httpClient = HttpClientDiscovery::find();
+            }
+        }
+        return $this->httpClient;
+    }
+
+    protected function getRequestFactory()
+    {
+        if (empty($this->requestFactory)) {
+            try {
+                $this->requestFactory = Psr17FactoryDiscovery::findRequestFactory();
+            } catch (DiscoveryNotFoundException $e) {
+                $this->requestFactory = MessageFactoryDiscovery::find();
+            }
+        }
+        return $this->requestFactory;
     }
 
     /**
@@ -48,16 +77,19 @@ final class Client implements ClientInterface
         $body = null,
         $protocolVersion = '1.1'
     ) {
-        $request = $this->requestFactory
-            ->createRequest($method, $uri)
-            ->withProtocolVersion($protocolVersion);
-
-        if ($body) {
-            $request = $request->withBody($body);
-        }
-
-        foreach ($headers as $name => $value) {
-            $request = $request->withHeader($name, $value);
+        if ($this->getRequestFactory() instanceof Psr18ClientInterface) {
+            $request = $this->requestFactory
+                ->createRequest($method, $uri)
+                ->withProtocolVersion($protocolVersion);
+            if ($body) {
+                $request = $request->withBody($body);
+            }
+            foreach ($headers as $name => $value) {
+                $request = $request->withHeader($name, $value);
+            }
+        } else {
+            $request = $this->getRequestFactory()
+                ->createRequest($method, $uri, $headers, $body, $protocolVersion);
         }
 
         return $this->sendRequest($request);
@@ -68,10 +100,10 @@ final class Client implements ClientInterface
      * @return ResponseInterface
      * @throws NetworkException|RequestException
      */
-    private function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request)
     {
         try {
-            return $this->httpClient->sendRequest($request);
+            return $this->getHttpClient()->sendRequest($request);
         } catch (\Http\Client\Exception\NetworkException $networkException) {
             throw new NetworkException($networkException->getMessage(), $request, $networkException);
         } catch (\Throwable $exception) {

--- a/tests/Omnipay/Common/Http/ClientTest.php
+++ b/tests/Omnipay/Common/Http/ClientTest.php
@@ -33,6 +33,9 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
+            [],
+            null,
+            '1.1',
         ])->andReturn($request);
 
         $mockClient->shouldReceive('sendRequest')
@@ -56,6 +59,9 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
+            [],
+            null,
+            '1.1',
         ])->andReturn($request);
 
         $mockClient->shouldReceive('sendRequest')
@@ -80,6 +86,9 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
+            [],
+            null,
+            '1.1',
         ])->andReturn($request);
 
         $mockClient->shouldReceive('sendRequest')
@@ -104,6 +113,9 @@ class ClientTest extends TestCase
         $mockFactory->shouldReceive('createRequest')->withArgs([
             'GET',
             '/path',
+            [],
+            null,
+            '1.1',
         ])->andReturn($request);
 
         $exception = new \Exception('Something went wrong');

--- a/tests/Omnipay/Common/Http/ClientTest.php
+++ b/tests/Omnipay/Common/Http/ClientTest.php
@@ -13,14 +13,6 @@ use Psr\Http\Message\RequestFactoryInterface;
 
 class ClientTest extends TestCase
 {
-    public function testEmptyConstruct()
-    {
-        $client = new Client();
-
-        $this->assertAttributeInstanceOf(ClientInterface::class, 'httpClient', $client);
-        $this->assertAttributeInstanceOf(RequestFactoryInterface::class, 'requestFactory', $client);
-    }
-
     public function testSend()
     {
         $mockClient = m::mock(ClientInterface::class);


### PR DESCRIPTION
- Restore old request() functionality
- Make sendRequest() public
- Load factories on first use
- PSR 17 and 18 discoveries, fallback if failed
- request() as PSR-17 if instance applies, fallback if not
- PSR 18 and 17 createRequest(), createStream() and createUri() factories
- Delete orphan ResponseInterface reference
- Add deprecation notice for request()
- Add deprecation notice for sendRequest() exceptions

@barryvdh Lacks tests for new functionality... though would be great if you tell me what you think about it