### PR TITLE
Make set/getParameter public on Gateway

### DIFF
--- a/src/Common/AbstractGateway.php
+++ b/src/Common/AbstractGateway.php
@@ -43,7 +43,10 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
  */
 abstract class AbstractGateway implements GatewayInterface
 {
-    use ParametersTrait;
+    use ParametersTrait {
+        setParameter as traitSetParameter;
+        getParameter as traitGetParameter;
+    }
 
     /**
      * @var ClientInterface
@@ -108,6 +111,25 @@ abstract class AbstractGateway implements GatewayInterface
     public function getDefaultParameters()
     {
         return array();
+    }
+
+    /**
+     * @param  string $key
+     * @return mixed
+     */
+    public function getParameter($key)
+    {
+        return $this->traitGetParameter($key);
+    }
+
+    /**
+     * @param  string $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setParameter($key, $value)
+    {
+        return $this->traitSetParameter($key, $value);
     }
 
     /**

--- a/src/Common/ParametersTrait.php
+++ b/src/Common/ParametersTrait.php
@@ -31,6 +31,7 @@ trait ParametersTrait
     /**
      * Get one parameter.
      *
+     * @param  string $key Parameter key
      * @return mixed A single parameter value.
      */
     protected function getParameter($key)

--- a/tests/Omnipay/Common/AbstractGatewayTest.php
+++ b/tests/Omnipay/Common/AbstractGatewayTest.php
@@ -10,9 +10,12 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 class AbstractGatewayTest extends TestCase
 {
+    /** @var \Omnipay\Common\AbstractGateway */
+    protected $gateway;
+
     public function setUp()
     {
-        $this->gateway = m::mock('\Omnipay\Common\AbstractGateway')->makePartial();
+        $this->gateway = new AbstractGatewayTest_MockAbstractGateway();
         $this->gateway->initialize();
     }
 
@@ -26,11 +29,12 @@ class AbstractGatewayTest extends TestCase
 
     public function testGetShortName()
     {
-        $this->assertSame('\\'.get_class($this->gateway), $this->gateway->getShortName());
+        $this->assertSame('Common_AbstractGatewayTest_MockAbstract', $this->gateway->getShortName());
     }
 
     public function testInitializeDefaults()
     {
+        $this->gateway = m::mock('\Omnipay\Common\AbstractGateway')->makePartial();
         $defaults = array(
             'currency' => 'AUD', // fixed default type
             'username' => array('joe', 'fred'), // enum default type
@@ -49,6 +53,7 @@ class AbstractGatewayTest extends TestCase
 
     public function testInitializeParameters()
     {
+        $this->gateway = m::mock('\Omnipay\Common\AbstractGateway')->makePartial();
         $this->gateway->shouldReceive('getDefaultParameters')->once()
             ->andReturn(array('currency' => 'AUD'));
 
@@ -70,6 +75,15 @@ class AbstractGatewayTest extends TestCase
         $this->gateway->setTestMode(true);
 
         $this->assertSame(array('testMode' => true), $this->gateway->getParameters());
+    }
+
+    public function testSetSetParameter()
+    {
+        $token = 'foobar';
+
+        $this->gateway->setParameter('token', $token);
+
+        $this->assertEquals($token, $this->gateway->getParameter('token'));
     }
 
     public function testTestMode()


### PR DESCRIPTION
These shouldn't be protected but public. Tests are fixed to pick this error up.

Fixes #217