### PR TITLE
Added "refunded" as possible payment notification state

### DIFF
--- a/src/Common/Message/NotificationInterface.php
+++ b/src/Common/Message/NotificationInterface.php
@@ -10,6 +10,7 @@ interface NotificationInterface extends MessageInterface
     const STATUS_COMPLETED = 'completed';
     const STATUS_PENDING = 'pending';
     const STATUS_FAILED = 'failed';
+    const STATUS_REFUNDED = 'refunded';
 
     /**
      * Gateway Reference


### PR DESCRIPTION
If payments are refunded and credited back to the customer in the backends of the payment providers, they notify the application that the payment status changed to "refunded". Omnipay drivers should be able to map the status sent by the payment gateway to an official Omnipay status that applications can use to mark transactions as refunded regardless of the driver.