### PR TITLE
corrects deprecated symfony 5.1

### DIFF
--- a/src/Common/Message/AbstractResponse.php
+++ b/src/Common/Message/AbstractResponse.php
@@ -207,7 +207,7 @@ abstract class AbstractResponse implements ResponseInterface
         $this->validateRedirect();
 
         if ('GET' === $this->getRedirectMethod()) {
-            return HttpRedirectResponse::create($this->getRedirectUrl());
+            return new HttpRedirectResponse($this->getRedirectUrl());
         }
 
         $hiddenFields = '';
@@ -241,7 +241,7 @@ abstract class AbstractResponse implements ResponseInterface
             $hiddenFields
         );
 
-        return HttpResponse::create($output);
+        return new HttpResponse($output);
     }
 
     /**


### PR DESCRIPTION
Hi,

Just a small change to avoid the symfony deprecation error (trigger_deprecated) for the static "create" methods.