### PR TITLE
Add default value to getParameter

### DIFF
--- a/src/Common/AbstractGateway.php
+++ b/src/Common/AbstractGateway.php
@@ -61,8 +61,8 @@ abstract class AbstractGateway implements GatewayInterface
     /**
      * Create a new gateway instance
      *
-     * @param ClientInterface          $httpClient  A HTTP client to make API calls with
-     * @param HttpRequest     $httpRequest A Symfony HTTP request object
+     * @param ClientInterface $httpClient A HTTP client to make API calls with
+     * @param HttpRequest $httpRequest A Symfony HTTP request object
      */
     public function __construct(ClientInterface $httpClient = null, HttpRequest $httpRequest = null)
     {
@@ -84,7 +84,7 @@ abstract class AbstractGateway implements GatewayInterface
     /**
      * Initialize this gateway with default parameters
      *
-     * @param  array $parameters
+     * @param array $parameters
      * @return $this
      */
     public function initialize(array $parameters = array())
@@ -114,17 +114,18 @@ abstract class AbstractGateway implements GatewayInterface
     }
 
     /**
-     * @param  string $key
+     * @param string $key
+     * @param null $default
      * @return mixed
      */
-    public function getParameter($key)
+    public function getParameter($key, $default = null)
     {
-        return $this->traitGetParameter($key);
+        return $this->traitGetParameter($key, $default);
     }
 
     /**
-     * @param  string $key
-     * @param  mixed  $value
+     * @param string $key
+     * @param mixed $value
      * @return $this
      */
     public function setParameter($key, $value)
@@ -141,7 +142,7 @@ abstract class AbstractGateway implements GatewayInterface
     }
 
     /**
-     * @param  boolean $value
+     * @param boolean $value
      * @return $this
      */
     public function setTestMode($value)
@@ -158,7 +159,7 @@ abstract class AbstractGateway implements GatewayInterface
     }
 
     /**
-     * @param  string $value
+     * @param string $value
      * @return $this
      */
     public function setCurrency($value)

--- a/src/Common/ParametersTrait.php
+++ b/src/Common/ParametersTrait.php
@@ -31,12 +31,13 @@ trait ParametersTrait
     /**
      * Get one parameter.
      *
-     * @param  string $key Parameter key
+     * @param string $key Parameter key
+     * @param null $default
      * @return mixed A single parameter value.
      */
-    protected function getParameter($key)
+    protected function getParameter($key, $default = null)
     {
-        return $this->parameters->get($key);
+        return $this->parameters->get($key, $default);
     }
 
     /**
@@ -77,7 +78,7 @@ trait ParametersTrait
     {
         foreach ($args as $key) {
             $value = $this->parameters->get($key);
-            if (! isset($value)) {
+            if (!isset($value)) {
                 throw new InvalidRequestException("The $key parameter is required");
             }
         }

--- a/tests/Omnipay/Common/AbstractGatewayTest.php
+++ b/tests/Omnipay/Common/AbstractGatewayTest.php
@@ -86,6 +86,18 @@ class AbstractGatewayTest extends TestCase
         $this->assertEquals($token, $this->gateway->getParameter('token'));
     }
 
+    public function testGetParameterWithDefaultValue()
+    {
+        $default = 'foo';
+
+        $this->assertEquals($default, $this->gateway->getParameter('foobar', $default));
+    }
+
+    public function testGetParameterWithoutDefaultValueIsEqualsToNull()
+    {
+        $this->assertEquals(null, $this->gateway->getParameter('foobar'));
+    }
+
     public function testTestMode()
     {
         $this->assertSame($this->gateway, $this->gateway->setTestMode(true));
@@ -195,6 +207,11 @@ class AbstractGatewayTest_MockAbstractGateway extends AbstractGateway
 
 class AbstractGatewayTest_MockAbstractRequest extends AbstractRequest
 {
-    public function getData() {}
-    public function sendData($data) {}
+    public function getData()
+    {
+    }
+
+    public function sendData($data)
+    {
+    }
 }


### PR DESCRIPTION
We need default option in getParameter like getParameter($key, $default = null). 

Because Symfony Parameter Bag is supporting this default return.