### PR TITLE
Add support for a third address line parameter

### DIFF
--- a/src/Common/CreditCard.php
+++ b/src/Common/CreditCard.php
@@ -44,6 +44,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * * company
  * * address1
  * * address2
+ * * address3
  * * city
  * * postcode
  * * state
@@ -66,6 +67,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * * billingCompany
  * * billingAddress1
  * * billingAddress2
+ * * billingAddress3
  * * billingCity
  * * billingPostcode
  * * billingState
@@ -79,6 +81,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * * shippingCompany
  * * shippingAddress1
  * * shippingAddress2
+ * * shippingAddress3
  * * shippingCity
  * * shippingPostcode
  * * shippingState
@@ -792,6 +795,27 @@ class CreditCard
     }
 
     /**
+     * Get the billing address, line 3.
+     *
+     * @return string
+     */
+    public function getBillingAddress3()
+    {
+        return $this->getParameter('billingAddress3');
+    }
+
+    /**
+     * Sets the billing address, line 3.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setBillingAddress3($value)
+    {
+        return $this->setParameter('billingAddress3', $value);
+    }
+
+    /**
      * Get the billing city.
      *
      * @return string
@@ -1091,6 +1115,27 @@ class CreditCard
     }
 
     /**
+     * Get the shipping address, line 3.
+     *
+     * @return string
+     */
+    public function getShippingAddress3()
+    {
+        return $this->getParameter('shippingAddress3');
+    }
+
+    /**
+     * Sets the shipping address, line 3.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setShippingAddress3($value)
+    {
+        return $this->setParameter('shippingAddress3', $value);
+    }
+
+    /**
      * Get the shipping city.
      *
      * @return string
@@ -1281,6 +1326,30 @@ class CreditCard
     {
         $this->setParameter('billingAddress2', $value);
         $this->setParameter('shippingAddress2', $value);
+
+        return $this;
+    }
+
+    /**
+     * Get the billing address, line 3.
+     *
+     * @return string
+     */
+    public function getAddress3()
+    {
+        return $this->getParameter('billingAddress3');
+    }
+
+    /**
+     * Sets the billing and shipping address, line 3.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setAddress3($value)
+    {
+        $this->setParameter('billingAddress3', $value);
+        $this->setParameter('shippingAddress3', $value);
 
         return $this;
     }

--- a/tests/Omnipay/Common/CreditCardTest.php
+++ b/tests/Omnipay/Common/CreditCardTest.php
@@ -428,6 +428,13 @@ class CreditCardTest extends TestCase
         $this->assertEquals('Suburb', $this->card->getAddress2());
     }
 
+    public function testBillingAddress3()
+    {
+        $this->card->setBillingAddress3('Building C, Room 308');
+        $this->assertEquals('Building C, Room 308', $this->card->getBillingAddress3());
+        $this->assertEquals('Building C, Room 308', $this->card->getAddress3());
+    }
+
     public function testBillingCity()
     {
         $this->card->setBillingCity('Quahog');
@@ -524,6 +531,12 @@ class CreditCardTest extends TestCase
         $this->assertEquals('Suburb', $this->card->getShippingAddress2());
     }
 
+    public function testShippingAddress3()
+    {
+        $this->card->setShippingAddress3('Building C, Room 308');
+        $this->assertEquals('Building C, Room 308', $this->card->getShippingAddress3());
+    }
+
     public function testShippingCity()
     {
         $this->card->setShippingCity('Quahog');
@@ -588,6 +601,14 @@ class CreditCardTest extends TestCase
         $this->assertEquals('Suburb', $this->card->getAddress2());
         $this->assertEquals('Suburb', $this->card->getBillingAddress2());
         $this->assertEquals('Suburb', $this->card->getShippingAddress2());
+    }
+
+    public function testAddress3()
+    {
+        $this->card->setAddress3('Building C, Room 308');
+        $this->assertEquals('Building C, Room 308', $this->card->getAddress3());
+        $this->assertEquals('Building C, Room 308', $this->card->getBillingAddress3());
+        $this->assertEquals('Building C, Room 308', $this->card->getShippingAddress3());
     }
 
     public function testCity()


### PR DESCRIPTION
Some payment gateways support an additional address line for more complex addresses. Rather than making additional accessors just for one line of addressing when everything else is supported by the `CreditCard` object, we can add support here directly.