### PR TITLE
GrumPHP v0.14.x isn't compatible with Composer2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,10 @@ matrix:
   allow_failures:	   
     - php: 5.6
     - php: 7.4
-    
+
+before_install:
+  - travis_retry composer self-update --1
+
 install:
   - if [[ $symfony != '*' ]]; then travis_retry composer require symfony/http-foundation:${symfony} --no-update --no-interaction; fi
   - if [[ $setup = 'basic' ]]; then travis_retry composer install --prefer-dist --no-interaction; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     - php: 7.4
 
 before_install:
-  - travis_retry composer self-update --1
+  - travis_retry composer remove --dev phpro/grumphp
 
 install:
   - if [[ $symfony != '*' ]]; then travis_retry composer require symfony/http-foundation:${symfony} --no-update --no-interaction; fi


### PR DESCRIPTION
The CI tests are failing because the required version of GrumPHP is incompatible with Composer Plugin API v2 - support was added in [v0.18.1](https://github.com/phpro/grumphp/releases/tag/v0.18.1), however by that point they had also dropped support for PHP 5.6, 7.0 and 7.1, which means our CI tests in those environments will always fail due to incompatible dependencies.

The alternative would be to fork GrumPHP v0.14.x and add Composer v2 support, open a PR and hope it isn't closed. Considering they are many versions past this an unlikely to care about PHP 5.6 at this point, that seems a bit unlikely?

Reverting Composer to 1.x for Travis seems like the fastest way around this, although this should be removed when Omnipay drops support for older versions of PHP and can update the dev-requirements to a newer version of GrumPHP.