### PR TITLE
Remove grumphp until it works with composer 2

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,5 +19,5 @@ checks:
 
 tools:
     external_code_coverage:
-        timeout: 600
+        timeout: 1200
         runs: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ install:
   - if [[ $setup = 'basic' ]]; then travis_retry composer install --prefer-dist --no-interaction; fi
   - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
 
+before_script:
+  - export XDEBUG_MODE=coverage
+
 script:
   - vendor/bin/phpcs --standard=PSR2 src/
   - vendor/bin/phpunit --coverage-text  --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,7 @@
     "require-dev": {
         "omnipay/tests": "^3",
         "php-http/mock-client": "^1",
-        "squizlabs/php_codesniffer": "^3.5",
-        "phpro/grumphp": "^0.14"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
It seems that grumphp doesn't work with composer 2 as yet - I think it makes sense to
remove it in the short term rather than have tests not work