### PR TITLE
allowing Classname::class syntax for getGatewayClassName()

### DIFF
--- a/src/Common/Helper.php
+++ b/src/Common/Helper.php
@@ -122,12 +122,15 @@ class Helper
      *      PayPal\Express      => \Omnipay\PayPal\ExpressGateway
      *      PayPal_Express      => \Omnipay\PayPal\ExpressGateway
      *
-     * @param  string  $shortName The short gateway name
+     * @param  string  $shortName The short gateway name or the FQCN
      * @return string  The fully namespaced gateway class name
      */
     public static function getGatewayClassName($shortName)
     {
         if (0 === strpos($shortName, '\\')) {
+            return $shortName;
+        }
+        if (0 === strpos($shortName, 'Omnipay\\')) {
             return $shortName;
         }
 

--- a/tests/Common/HelperTest.php
+++ b/tests/Common/HelperTest.php
@@ -143,4 +143,10 @@ class HelperTest extends TestCase
         $class = Helper::getGatewayClassName('PayPal_Express');
         $this->assertEquals('\\Omnipay\\PayPal\\ExpressGateway', $class);
     }
+
+    public function testGetGatewayClassNameFQCN()
+    {
+        $class = Helper::getGatewayClassName('Omnipay\Stripe\PaymentIntentsGateway');
+        $this->assertEquals('Omnipay\Stripe\PaymentIntentsGateway', $class);
+    }
 }


### PR DESCRIPTION
See : https://github.com/thephpleague/omnipay/issues/650