### PR TITLE
Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "php-http/client-implementation": "^1",
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.14",
-        "symfony/http-foundation": "^2.1|^3|^4|^5",
+        "symfony/http-foundation": "^2.1|^3|^4|^5|^6",
         "moneyphp/money": "^3.1|^4.0.3"
     },
     "require-dev": {


### PR DESCRIPTION
Allows `symfony/http-foundation` v6.x, tests pass locally