### PR TITLE
Allow usage of `moneyphp/money:^4.0.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "php-http/message": "^1.5",
         "php-http/discovery": "^1.14",
         "symfony/http-foundation": "^2.1|^3|^4|^5",
-        "moneyphp/money": "^3.1"
+        "moneyphp/money": "^3.1|^4.0.3"
     },
     "require-dev": {
         "omnipay/tests": "^4.1",


### PR DESCRIPTION
@barryvdh unsure about how this can be properly tested, besides pre-existing tests: ideally, `vimeo/psalm` should be included in the toolchain :thinking: 