### PR TITLE
require php-http/message-factory directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "php": "^7.2|^8",
         "php-http/client-implementation": "^1",
         "php-http/message": "^1.5",
+        "php-http/message-factory": "^1.1",
         "php-http/discovery": "^1.14",
         "symfony/http-foundation": "^2.1|^3|^4|^5|^6",
         "moneyphp/money": "^3.1|^4.0.3"


### PR DESCRIPTION
This library still uses the deprecated php-http message factories. They have been deprecated since a while in favor of PSR-17 message factories.

php-http/discovery no longer automatically installs php-http/message-factory.

This is a quickfix for the issue. The real fix will be to change to the PSR-17 RequestFactoryInterface in [omnium http client](https://github.com/thephpleague/omnipay-common/blob/master/src/Common/Http/Client.php) and use [Psr17FactoryDiscovery](https://github.com/php-http/discovery/blob/1.x/src/Psr17FactoryDiscovery.php)