### PR TITLE
Fix deprecated issues

### DIFF
--- a/src/Common/CreditCard.php
+++ b/src/Common/CreditCard.php
@@ -377,7 +377,7 @@ class CreditCard
     public function setNumber($value)
     {
         // strip non-numeric characters
-        return $this->setParameter('number', preg_replace('/\D/', '', $value));
+        return $this->setParameter('number', preg_replace('/\D/', '', (string) $value));
     }
 
     /**
@@ -412,8 +412,10 @@ class CreditCard
      */
     public function getBrand()
     {
+        $number = (string) $this->getNumber();
+
         foreach ($this->getSupportedBrands() as $brand => $val) {
-            if (preg_match($val, $this->getNumber())) {
+            if (preg_match($val, $number)) {
                 return $brand;
             }
         }

--- a/src/Common/Helper.php
+++ b/src/Common/Helper.php
@@ -63,7 +63,7 @@ class Helper
     public static function validateLuhn($number)
     {
         $str = '';
-        foreach (array_reverse(str_split($number)) as $i => $c) {
+        foreach (array_reverse(str_split((string) $number)) as $i => $c) {
             $str .= $i % 2 ? $c * 2 : $c;
         }
 

--- a/src/Common/Message/AbstractResponse.php
+++ b/src/Common/Message/AbstractResponse.php
@@ -215,7 +215,7 @@ abstract class AbstractResponse implements ResponseInterface
             $hiddenFields .= sprintf(
                 '<input type="hidden" name="%1$s" value="%2$s" />',
                 htmlentities($key, ENT_QUOTES, 'UTF-8', false),
-                htmlentities($value, ENT_QUOTES, 'UTF-8', false)
+                htmlentities((string) $value, ENT_QUOTES, 'UTF-8', false)
             )."\n";
         }
 

--- a/tests/Common/GatewayFactoryTest.php
+++ b/tests/Common/GatewayFactoryTest.php
@@ -7,6 +7,9 @@ use Omnipay\Tests\TestCase;
 
 class GatewayFactoryTest extends TestCase
 {
+    /** @var GatewayFactory  */
+    protected $factory;
+
     public static function setUpBeforeClass() : void
     {
         m::mock('alias:Omnipay\\SpareChange\\TestGateway');

--- a/tests/Common/ItemBagTest.php
+++ b/tests/Common/ItemBagTest.php
@@ -6,6 +6,9 @@ use Omnipay\Tests\TestCase;
 
 class ItemBagTest extends TestCase
 {
+    /** @var ItemBag  */
+    protected $bag;
+
     public function setUp() : void
     {
         $this->bag = new ItemBag;

--- a/tests/Common/ItemTest.php
+++ b/tests/Common/ItemTest.php
@@ -6,6 +6,9 @@ use Omnipay\Tests\TestCase;
 
 class ItemTest extends TestCase
 {
+    /** @var Item  */
+    protected $item;
+
     public function setUp() : void
     {
         $this->item = new Item;


### PR DESCRIPTION
Cast value to string. It would be better to check for null but the typehint suggest is should be `string`. So keeping types as-is.
Fixes #260