### PR TITLE
Add standard getCreateToken/setCreateToken request methods

### DIFF
--- a/src/Common/Message/AbstractRequest.php
+++ b/src/Common/Message/AbstractRequest.php
@@ -205,6 +205,27 @@ abstract class AbstractRequest implements RequestInterface
     }
 
     /**
+     * Set whether you wish to generate and store a card token with this request.
+     *
+     * @param bool $value
+     * @return $this
+     */
+    public function setCreateToken($value)
+    {
+        return $this->setParameter('createToken', $value);
+    }
+
+    /**
+     * Get whether you wish to generate and store a card token with this request.
+     *
+     * @return bool
+     */
+    public function getCreateToken()
+    {
+        return $this->getParameter('createToken');
+    }
+
+    /**
      * Get the card token.
      *
      * @return string

--- a/tests/Common/Message/AbstractRequestTest.php
+++ b/tests/Common/Message/AbstractRequestTest.php
@@ -78,6 +78,12 @@ class AbstractRequestTest extends TestCase
         $this->assertSame('1234', $card->getNumber());
     }
 
+    public function testCreateToken()
+    {
+        $this->assertSame($this->request, $this->request->setCreateToken(true));
+        $this->assertTrue($this->request->getCreateToken());
+    }
+
     public function testToken()
     {
         $this->assertSame($this->request, $this->request->setToken('12345'));


### PR DESCRIPTION
Most payment processors seem to have a "please store my card details" feature, where they pass back a token to the merchant to represent the card. We already have standard `getToken()` and `getCardReference()` methods for this parameter if it exists to pass along instead of card details, but no standard method for indicating that the token should be created as a part of the request in the first place.

Usually this means it ends up as an implementation detail with whatever the parameter is called (tokenize, tokenMode, storeCard, etc.) and is one more detail that must be accounted for per-processor rather than something that can be relied on at a higher level to be a consistent flag.

This PR standardizes that flag as `getCreateToken()` and `setCreateToken()` (the same as https://github.com/thephpleague/omnipay-sagepay/) so we can reliably set it once and know the driver will convert it appropriately.