### PR TITLE
Add support for PHPUnit 10+ to CI process

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -50,5 +50,10 @@ jobs:
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress"
 
-      - name: "Tests"
+      - name: "Tests (PHPUnit 9)"
+        if: ${{ matrix.php-version <= '8.0' }}
+        run: "vendor/bin/phpunit --configuration phpunit9.xml.dist"
+
+      - name: "Tests (PHPUnit 10+)"
+        if: ${{ matrix.php-version >= '8.1' }}
         run: "vendor/bin/phpunit"

--- a/phpunit9.xml.dist
+++ b/phpunit9.xml.dist
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticProperties="false"
+         backupStaticAttributes="false"
          colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage"/>
       <text outputFile="build/coverage.txt"/>
     </report>
   </coverage>
-  <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </source>
   <testsuites>
     <testsuite name="Omnipay Test Suite">
       <directory>tests</directory>


### PR DESCRIPTION
CI was failing on #275 due to higher versions of PHP using newer versions of PHPUnit, which has a different XML configuration file format. This should fix just the CI runner process to allow for that.