### PR TITLE
Fixed 8.4 deprecation inside AbstractClient

### DIFF
--- a/src/Common/Http/AbstractClient.php
+++ b/src/Common/Http/AbstractClient.php
@@ -28,7 +28,7 @@ abstract class AbstractClient implements ClientInterface
 
     public function __construct(
         $httpClient = null,
-        RequestFactoryInterface|RequestFactory $requestFactory = null,
+        null|RequestFactoryInterface|RequestFactory $requestFactory = null,
         ?StreamFactoryInterface $streamFactory = null
     ) {
         $this->httpClient = $httpClient ?: Psr18ClientDiscovery::find();


### PR DESCRIPTION
This fixes a 8.4 deprecation that was added in v3.5.0 (https://github.com/thephpleague/omnipay-common/pull/282).

Is it possible to release a patch version shortly after this PR is merged?